### PR TITLE
Update wp-tevko-responsive-images.php

### DIFF
--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -8,7 +8,7 @@ defined('ABSPATH') or die("No script kiddies please!");
  * @wordpress-plugin
  * Plugin Name:       WP Tevko Responsive Images
  * Plugin URI:        http://css-tricks.com/hassle-free-responsive-images-for-wordpress/
- * Description:       Bringing automatic default responsive images to wordpress
+ * Description:       Bringing automatic default responsive images to WordPress
  * Version:           2.0.0
  * Author:            Tim Evko
  * Author URI:        http://timevko.com/


### PR DESCRIPTION
Fixing error when I tried to activate the plugin:
`Parse error: syntax error, unexpected '[' in /srv/www/vhosts/wptest/wp-content/plugins/respimg/wp-tevko-responsive-images.php on line 52`
Function array dereferencing is unsupported in PHP 5.3 but was [added in 5.4](http://php.net/manual/en/migration54.new-features.php).
Since WordPress only requires [PHP version 5.2.4 or greater](https://wordpress.org/about/requirements/)  other people might try to use the plugin using older versions of PHP.
