### PR TITLE
Pr

### DIFF
--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -69,7 +69,6 @@ function tevkori_get_src_sizes( $id, $size ) {
         
         // Reference the size directly by it's pixel dimension
         $image_src = wp_get_attachment_image_src( $id, $key );
-        //$image_src = cv_resize( $id, $size, $size, false );
         $arr[] = $image_src[0] . ' ' . $size['width'] .'w';
     }
 


### PR DESCRIPTION
You can pass the $size along with image_send_to_editor. With this information we can choose to not include unnecessary crops.

Also, by using wp_get_attachment_metadata we can check the sizes that actually exist for the image. with this, we can confidently loop through the crops forgoing a lot of the conditional checks around like #59.

[Screenshot of html output using built in WP sizes](https://cloudup.com/c2jwoZ91Fbd)
