### PR TITLE
Recalculate srcset attribute if image is updated in the editor

### DIFF
--- a/js/wp-tevko-responsive-images.js
+++ b/js/wp-tevko-responsive-images.js
@@ -7,8 +7,10 @@
    */
   wp.media.events.on( 'editor:image-update', function( args ) {
     // arguments[0] = { Editor, image, metadata }
-    var image = args.image,
-      metadata = args.metadata;
+	  var image = args.image,
+			metadata = args.metadata,
+			srcsetGroup = [],
+			srcset = '';
 
     // if the image url has changed, recalculate srcset attributes
     if ( metadata && metadata.url !== metadata.originalUrl ) {
@@ -17,16 +19,11 @@
       var imagePostData = new wp.media.model.PostImage( metadata ),
         sizes = imagePostData.attachment.attributes.sizes;
 
-      // calculate our target ratio and set up placeholders to hold our updated srcset data
-      var newRatio = metadata.width / metadata.height,
-        srcset = '',
-        srcsetGroup = [];
-
-      // grab all the sizes that match our target ratio and add them to our srcsetGroup array
+      // grab all the sizes that match our target ratio and add them to our srcset array
       _.each(sizes, function(size){
-        var sizeRatio = size.width / size.height;
+        var softHeight = Math.round( size.width * metadata.height / metadata.width );
 
-        if (sizeRatio === newRatio) {
+        if (softHeight === size.height) {
           srcsetGroup.push(size.url + ' ' + size.width + 'w');
         }
       });

--- a/js/wp-tevko-responsive-images.js
+++ b/js/wp-tevko-responsive-images.js
@@ -1,0 +1,43 @@
+"use strict";
+
+(function() {
+
+  /**
+   * Recalculate srcset attribute after an image-update event
+   */
+  wp.media.events.on( 'editor:image-update', function( args ) {
+    // arguments[0] = { Editor, image, metadata }
+    var image = args.image,
+      metadata = args.metadata;
+
+    // if the image url has changed, recalculate srcset attributes
+    if ( metadata && metadata.url !== metadata.originalUrl ) {
+      // we need to get the postdata for the image because
+      // the sizes array isn't passed into the editor
+      var imagePostData = new wp.media.model.PostImage( metadata ),
+        sizes = imagePostData.attachment.attributes.sizes;
+
+      // calculate our target ratio and set up placeholders to hold our updated srcset data
+      var newRatio = metadata.width / metadata.height,
+        srcset = '',
+        srcsetGroup = [];
+
+      // grab all the sizes that match our target ratio and add them to our srcsetGroup array
+      _.each(sizes, function(size){
+        var sizeRatio = size.width / size.height;
+
+        if (sizeRatio === newRatio) {
+          srcsetGroup.push(size.url + ' ' + size.width + 'w');
+        }
+      });
+
+      // convert the srcsetGroup array to our srcset value
+      srcset = srcsetGroup.join(', ');
+
+      // update the srcset attribute of our image
+      image.setAttribute( 'srcset', srcset );
+    }
+
+  });
+
+})();

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -122,7 +122,7 @@ add_action( 'admin_print_footer_scripts', function() {
 					sizes = post.attachment.attributes.sizes;
 
 				// calculate our target ratio and set up placeholders to hold our updated srcset data
-				var newRatio = image.width / image.height,
+				var newRatio = metadata.width / metadata.height,
 					srcset = '',
 					srcsetGroup = [];
 

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -100,3 +100,51 @@ add_filter( 'image_send_to_editor', 'tevkori_extend_image_tag', 0, 8 );
 function tevkori_editor_image_size( $max_image_size ){
 	return array( 99999, 99999 );
 }
+
+// Hook and priority loads after tinymce.js and its plugins.
+add_action( 'admin_print_footer_scripts', function() {
+	?><script>
+	(function($) {
+
+		/**
+		 * Recalculate srcset attribute after an image-update event
+		 */
+		wp.media.events.on( 'editor:image-update', function( arguments ) {
+			// arguments[0] = { Editor, image, metadata }
+			var image = arguments.image
+				metadata = arguments.metadata;
+
+			// if the image url has changed, recalculate srcset attributes
+			if ( metadata && metadata.url !== metadata.originalUrl ) {
+				// we need toget the postdata for the image because
+				// the sizes array isn't passed into the editor
+				var post = new wp.media.model.PostImage( metadata ),
+					sizes = post.attachment.attributes.sizes;
+
+				// calculate our target ratio and set up placeholders to hold our updated srcset data
+				var newRatio = image.width / image.height,
+					srcset = '',
+					srcsetGroup = [];
+
+				// grab all the sizes that match our target ratio and add them to our srcsetGroup array
+				_.each(sizes, function(size){
+					var sizeRatio = size.width / size.height;
+
+					if (sizeRatio == newRatio) {
+						srcsetGroup.push(size.url + ' ' + size.width + 'w');
+					}
+				});
+
+				// convert the srcsetGroup array to our srcset value
+				srcset = srcsetGroup.join(', ');
+
+				// update the srcset attribute of our image
+				image.setAttribute( 'srcset', srcset );
+			}
+
+		});
+
+	})(jQuery);
+	</script>
+	<?php
+}, 100 );

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -101,50 +101,7 @@ function tevkori_editor_image_size( $max_image_size ){
 	return array( 99999, 99999 );
 }
 
-// Hook and priority loads after tinymce.js and its plugins.
-add_action( 'admin_print_footer_scripts', function() {
-	?><script>
-	(function($) {
-
-		/**
-		 * Recalculate srcset attribute after an image-update event
-		 */
-		wp.media.events.on( 'editor:image-update', function( arguments ) {
-			// arguments[0] = { Editor, image, metadata }
-			var image = arguments.image
-				metadata = arguments.metadata;
-
-			// if the image url has changed, recalculate srcset attributes
-			if ( metadata && metadata.url !== metadata.originalUrl ) {
-				// we need toget the postdata for the image because
-				// the sizes array isn't passed into the editor
-				var post = new wp.media.model.PostImage( metadata ),
-					sizes = post.attachment.attributes.sizes;
-
-				// calculate our target ratio and set up placeholders to hold our updated srcset data
-				var newRatio = metadata.width / metadata.height,
-					srcset = '',
-					srcsetGroup = [];
-
-				// grab all the sizes that match our target ratio and add them to our srcsetGroup array
-				_.each(sizes, function(size){
-					var sizeRatio = size.width / size.height;
-
-					if (sizeRatio == newRatio) {
-						srcsetGroup.push(size.url + ' ' + size.width + 'w');
-					}
-				});
-
-				// convert the srcsetGroup array to our srcset value
-				srcset = srcsetGroup.join(', ');
-
-				// update the srcset attribute of our image
-				image.setAttribute( 'srcset', srcset );
-			}
-
-		});
-
-	})(jQuery);
-	</script>
-	<?php
-}, 100 );
+function tevkori_load_scripts() {
+	wp_enqueue_script( 'wp-tevko-responsive-images', plugin_dir_url( __FILE__ ) . 'js/wp-tevko-responsive-images.js', array('wp-backbone'), '2.0.0', true );
+}
+add_action( 'admin_enqueue_scripts', 'tevkori_load_scripts' );

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -101,7 +101,9 @@ function tevkori_editor_image_size( $max_image_size ){
 	return array( 99999, 99999 );
 }
 
-function tevkori_load_scripts() {
-	wp_enqueue_script( 'wp-tevko-responsive-images', plugin_dir_url( __FILE__ ) . 'js/wp-tevko-responsive-images.js', array('wp-backbone'), '2.0.0', true );
+function tevkori_load_admin_scripts( $hook ) {
+	if ($hook == 'post.php' || $hook == 'post-new.php') {
+		wp_enqueue_script( 'wp-tevko-responsive-images', plugin_dir_url( __FILE__ ) . 'js/wp-tevko-responsive-images.js', array('wp-backbone'), '2.0.0', true );
+	}
 }
-add_action( 'admin_enqueue_scripts', 'tevkori_load_scripts' );
+add_action( 'admin_enqueue_scripts', 'tevkori_load_admin_scripts' );


### PR DESCRIPTION
I noticed that the srcset attribute doesn't get recalculated when the image size is changed in the editor, which can lead to incorrect srcset values on an image. For example, if the image size is edited from one of the default sizes to the thumbnail, the srcset values would need to change (and vice versa).

This commit adds a script that listens for the `editor:image-update` event and recalculates the srcset if the image url has changed (i.e., a different size has been selected).