### PR TITLE
Fix rounding bug in update editor JS

### DIFF
--- a/js/wp-tevko-responsive-images.js
+++ b/js/wp-tevko-responsive-images.js
@@ -23,7 +23,8 @@
       _.each(sizes, function(size){
         var softHeight = Math.round( size.width * metadata.height / metadata.width );
 
-        if (softHeight === size.height) {
+        // If the height is within 1 integer of the expected height, let it pass.
+        if ( size.height >= softHeight - 1 && size.height <= softHeight + 1  ) {
           srcsetGroup.push(size.url + ' ' + size.width + 'w');
         }
       });


### PR DESCRIPTION
When calculating expected sizes for `srcset` candidates in the updater, the rounding could be off by a single pixel. Now if the height of an image size is within 1 integer of the expected height in either direction, we let it pass.

(Fixes #37)