### PR TITLE
Add support for the sizes attribute.

### DIFF
--- a/js/wp-tevko-responsive-images.js
+++ b/js/wp-tevko-responsive-images.js
@@ -10,17 +10,18 @@
 	  var image = args.image,
 			metadata = args.metadata,
 			srcsetGroup = [],
-			srcset = '';
+			srcset = '',
+      sizes = '';
 
     // if the image url has changed, recalculate srcset attributes
     if ( metadata && metadata.url !== metadata.originalUrl ) {
       // we need to get the postdata for the image because
       // the sizes array isn't passed into the editor
       var imagePostData = new wp.media.model.PostImage( metadata ),
-        sizes = imagePostData.attachment.attributes.sizes;
+        crops = imagePostData.attachment.attributes.sizes;
 
       // grab all the sizes that match our target ratio and add them to our srcset array
-      _.each(sizes, function(size){
+      _.each(crops, function(size){
         var softHeight = Math.round( size.width * metadata.height / metadata.width );
 
         // If the height is within 1 integer of the expected height, let it pass.
@@ -31,9 +32,13 @@
 
       // convert the srcsetGroup array to our srcset value
       srcset = srcsetGroup.join(', ');
+      sizes = '(max-width: ' + metadata.width + 'px) 100vw, ' + metadata.width + 'px';
 
       // update the srcset attribute of our image
       image.setAttribute( 'srcset', srcset );
+
+      // update the sizes attribute of our image
+      image.setAttribute( 'data-sizes', sizes );
     }
 
   });

--- a/tests/test-suite.php
+++ b/tests/test-suite.php
@@ -63,6 +63,70 @@ class SampleTest extends WP_UnitTestCase {
 
 	/* OUR TESTS */
 
+	function test_tevkori_get_sizes() {
+		// make an image
+		$id = $this->_test_img();
+
+		global $content_width;
+
+		// test sizes against the default WP sizes
+		$intermediates = array('thumbnail', 'medium', 'large');
+
+		foreach( $intermediates as $int ) {
+			$width = get_option( $int . '_size_w' );
+
+			// the sizes width gets constrained to $content_width by default
+			if ( $content_width > 0 ) {
+				$width = ( $width > $content_width ) ? $content_width : $width;
+			}
+
+			$expected = '(max-width: ' . $width . 'px) 100vw, ' . $width . 'px';
+			$sizes = tevkori_get_sizes( $id, $int );
+
+			$this->assertSame($expected, $sizes);
+		}
+	}
+
+	function test_tevkori_get_sizes_with_args() {
+		// make an image
+		$id = $this->_test_img();
+
+		$args = array(
+			'sizes' => array(
+				array(
+					'size_value' 	=> '10em',
+					'mq_value'		=> '60em',
+					'mq_name'			=> 'min-width'
+				),
+				array(
+					'size_value' 	=> '20em',
+					'mq_value'		=> '30em',
+					'mq_name'			=> 'min-width'
+				),
+				array(
+					'size_value'	=> 'calc(100vm - 30px)'
+				),
+			)
+		);
+
+		$expected = '(min-width: 60em) 10em, (min-width: 30em) 20em, calc(100vm - 30px)';
+		$sizes = tevkori_get_sizes( $id, 'medium', $args );
+
+		$this->assertSame($expected, $sizes);
+	}
+
+	function test_tevkori_get_sizes_string() {
+		// make an image
+		$id = $this->_test_img();
+
+		$sizes = tevkori_get_sizes($id, 'medium');
+		$sizes_string = tevkori_get_sizes_string( $id, 'medium' );
+
+		$expected = 'sizes="' . $sizes . '"';
+
+		$this->assertSame( $expected, $sizes_string);
+	}
+
 	function test_tevkori_get_srcset_array() {
 		// make an image
 		$id = $this->_test_img();

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -26,6 +26,109 @@ function tevkori_get_picturefill() {
 add_action( 'wp_enqueue_scripts', 'tevkori_get_picturefill' );
 
 /**
+ * Return a source size attribute for an image from an array of values.
+ *
+ * @since 2.2.0
+ *
+ * @param int $id 			Image attacment ID.
+ * @param string $size	Optional. Name of image size. Default value: 'thumbnail'.
+ * @param array $args {
+ *     Optional. Arguments to retrieve posts.
+ *
+ *     @type array|string 	$sizes     An array or string containing of size information.
+ * }
+ * @return string|bool A valid source size value for use in a 'sizes' attribute or false.
+ */
+function tevkori_get_sizes( $id, $size = 'thumbnail', $args = null ) {
+	// See which image is being returned and bail if none is found
+	if ( ! $image = image_downsize( $id, $size ) ) {
+		return false;
+	};
+
+	// Get the image width
+	$img_width = $image[1] . 'px';
+
+	// Set up our default values
+	$defaults = array(
+		'sizes' => array(
+			array(
+				'size_value' 	=> '100vw',
+				'mq_value'		=> $img_width,
+				'mq_name'			=> 'max-width'
+			),
+			array(
+				'size_value'	=> $img_width
+			),
+		)
+	);
+
+	$args = wp_parse_args( $args, $defaults );
+
+	// If sizes is passed as a string, just use the string
+	if ( is_string( $args['sizes'] ) ) {
+		$size_list = $args['sizes'];
+
+	// Otherwise, breakdown the array and build a sizes string
+	} elseif ( is_array( $args['sizes'] ) ) {
+
+		$size_list = '';
+
+		foreach( $args['sizes'] as $size ) {
+			// Use 100vw as the size value unless something else is specified.
+			$size_value = ( $size['size_value'] ) ? $size['size_value'] : '100vw';
+
+			// If a media length is specified, build the media query.
+			if ( ! empty($size['mq_value']) ) {
+
+				$media_length = $size['mq_value'];
+
+				// Use max-width as the media condition unless min-width is specified.
+				$media_condition = ( ! empty($size['mq_name']) ) ? $size['mq_name'] : 'max-width';
+
+				// If a media_length was set, create the media query.
+				$media_query = '(' . $media_condition . ": " . $media_length . ') ';
+
+			} else {
+				// If not meda length was set, $media_query is blank
+				$media_query = '';
+			}
+
+			// Add to the source size list string.
+			$size_list .= $media_query . $size_value . ', ';
+		}
+
+		// Remove the trailing comma and space from the end of the string.
+		$size_list = substr($size_list, 0, -2);
+	}
+
+	// If $size_list is defined set the string, otherwise set false.
+	$size_string = ( $size_list ) ? $size_list : false;
+
+	return $size_string;
+}
+
+/**
+* Return a source size list for an image from an array of values.
+*
+* @since 2.2.0
+*
+* @param int $id 			Image attacment ID.
+* @param string $size	Optional. Name of image size. Default value: 'thumbnail'.
+* @param array $args {
+*     Optional. Arguments to retrieve posts.
+*
+*     @type array|string 	$sizes     An array or string containing of size information.
+* }
+* @return string|bool A valid source size list as a 'sizes' attribute or false.
+*/
+function tevkori_get_sizes_string( $id, $size = 'thumbnail', $args = null ) {
+	$sizes = tevkori_get_sizes( $id, $size, $args );
+	$sizes_string = $sizes ? 'sizes="' . $sizes . '"' : false;
+
+	return $sizes_string;
+}
+
+/**
  * Get an array of image sources candidates for use in a 'srcset' attribute.
  *
  * @param int $id 			Image attacment ID.
@@ -120,9 +223,16 @@ function tevkori_get_src_sizes( $id, $size = 'thumbnail' ) {
  */
 function tevkori_extend_image_tag( $html, $id, $caption, $title, $align, $url, $size, $alt ) {
 	add_filter( 'editor_max_image_size', 'tevkori_editor_image_size' );
+
+	$sizes = tevkori_get_sizes( $id, $size );
+	// Build the data-sizes attribute if sizes were returned.
+	if ( $sizes ) {
+		$sizes = 'data-sizes="' . $sizes . '"';
+	}
+	// Build the srcset attribute.
 	$srcset = tevkori_get_srcset_string( $id, $size );
 	remove_filter( 'editor_max_image_size', 'tevkori_editor_image_size' );
-	$html = preg_replace( '/(src\s*=\s*"(.+?)")/', '$1' . ' ' . $srcset, $html );
+	$html = preg_replace( '/(src\s*=\s*"(.+?)")/', '$1 ' . $sizes . ' ' . $srcset, $html );
 	return $html;
 }
 add_filter( 'image_send_to_editor', 'tevkori_extend_image_tag', 0, 8 );
@@ -139,8 +249,14 @@ function tevkori_filter_post_thumbnail_html( $html, $post_id, $post_thumbnail_id
 		return;
 	}
 
+	$sizes = tevkori_get_sizes( $post_thumbnail_id, $size );
+	// Build the data-sizes attribute if sizes were returned.
+	if ( $sizes ) {
+		$sizes = 'sizes="' . $sizes . '"';
+	}
+
 	$srcset = tevkori_get_srcset_string( $post_thumbnail_id, $size );
-	$html = preg_replace( '/(src\s*=\s*"(.+?)")/', '$1' . ' ' . $srcset, $html );
+	$html = preg_replace( '/(src\s*=\s*"(.+?)")/', '$1 ' . $sizes . ' ' . $srcset, $html );
 	return $html;
 }
 add_filter( 'post_thumbnail_html', 'tevkori_filter_post_thumbnail_html', 0, 5);
@@ -166,3 +282,20 @@ function tevkori_load_admin_scripts( $hook ) {
 	}
 }
 add_action( 'admin_enqueue_scripts', 'tevkori_load_admin_scripts' );
+
+
+/**
+ * Filter for the_content to replace data-size attributes with size attributes
+ *
+ * @since 2.2.0
+ *
+ * @param string 		$content 		The raw post content to be filtered.
+ */
+function tevkori_filter_content_sizes( $content ) {
+	$images = '/(<img\s.*?)data-sizes="([^"]+)"/i';
+	$sizes = '${2}';
+	$content = preg_replace( $images, '${1}sizes="' . $sizes . '"', $content );
+
+	return $content;
+}
+add_filter('the_content', 'tevkori_filter_content_sizes');


### PR DESCRIPTION
Here's an initial candidate for how we can handle default support for the `sizes` attribute in this plugin.

## Background

As discussed in #34, we need a way to set a smart default value for the `sizes` attribute when we are including a source set list using w descriptors. Otherwise, we run the risk of fooling the browser into downloading larger resources than necessary by assuming the image layout width is equal to 100% of the viewport width (among other issues). For the purpose of this pull request, I'm using the following pattern as the default for `sizes`:

```
sizes="( max-width: {{image-width}} ) 100vw, {{image-width}}"
```

In other words, when the viewport is less than or equal to the width of the main image, assume the image takes up the full screen width. If the viewport is greater than the width of the image, just use the width of the image itself as the layout width.

## The case for `data-sizes`

For this implementation, I've opted to include the sizes list as a `data-sizes` attribute instead of a `sizes` attribute directly. Here are my reasons:

First, It's important to remember that this plugin works by adding markup directly to the image HTML element before it's inserted into the editor, so we need to be careful about what we're saving to user's databases. Since `srcset` lists are unlikely to change over time and the attribute is now part of the HTML spec, we're probably safe there. On the other hand, the `sizes` attribute is completely dependent on the site's layout, which is theme territory and something we should be very careful about saving into users' databases.

Also, as of this writing, the version of TinyMCE that is bundled in WordPress core does not include support for the `sizes` attribute on image elements, so even if we _did_ add `sizes` to images, TinyMCE would just strip them right off. We can extend TinyMCE, and I've included a filter which does just that, but it currently breaks the wp.media view so I have it commented out for now. :-1: 

I've added new filters to `the_content` and `post_thumbnail_html` that simply looks for images with `data-sizes` attributes and change them to `sizes` attributes instead. 

While I'll be the first to admit that this approach isn't perfect, I see several benefits this strategy. Primarily, it allows us to deliver a default sizes attribute out of the box, which is a nice win. Developers will have the flexibility to alter the filters to their own liking in order to improve the accuracy of the sizes attributes without writing a bunch of code, which is pretty nice. Maybe most importantly, saving data attributes to the post data instead of the `sizes` attribute buys us some flexibility while we work out better ways of handling this in the future.