### PR TITLE
Make default params for optional '$sizes' match docs

### DIFF
--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -32,7 +32,7 @@ add_action( 'wp_enqueue_scripts', 'tevkori_get_picturefill' );
  * @param string $size	Optional. Name of image size. Default value: 'thumbnail'.
  * @return array|bool 	An array of of srcset values or false.
  */
-function tevkori_get_srcset_array( $id, $size ) {
+function tevkori_get_srcset_array( $id, $size = 'thumbnail' ) {
 	$arr = array();
 
 	// See which image is being returned and bail if none is found
@@ -90,7 +90,7 @@ function tevkori_get_srcset_array( $id, $size ) {
  * @param string $size	Optional. Name of image size. Default value: 'thumbnail'.
  * @return string|bool 	A full 'srcset' string or false.
  */
-function tevkori_get_srcset_string( $id, $size ) {
+function tevkori_get_srcset_string( $id, $size = 'thumbnail' ) {
 	$srcset_array = tevkori_get_srcset_array( $id, $size );
 	if ( empty( $srcset_array ) ) {
 		return false;
@@ -108,7 +108,7 @@ function tevkori_get_srcset_string( $id, $size ) {
  * @param int $id 			Image attacment ID.
  * @return string|bool 	A full 'srcset' string or false.
  */
-function tevkori_get_src_sizes($id, $size) {
+function tevkori_get_src_sizes( $id, $size = 'thumbnail' ) {
 	return tevkori_get_srcset_string( $id, $size );
 }
 


### PR DESCRIPTION
Without setting the default params for when functions are called without passing a `$size` parameter, the intent was to default to 'thumbnail' in order to mimic the default behavior of `wp_get_attachment_image_src()`, but currently 'null' is being passed to `wp_get_attachment_image_src()`, which ends up returning the full size instead of the default 'thumbnail' size. This pull request fixes that issue by explicitly setting a default value for `$size` to 'thumbnail' in all functions.