### PR TITLE
Account for rounding variance when matching ascpect ratios.

### DIFF
--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -63,7 +63,7 @@ function tevkori_get_srcset_array( $id, $size ) {
 		$soft_height = (int) round( $image_size['width'] * $img_height / $img_width );
 
 		// If image height varies more than 1px over the expected, throw it out.
-		if ( $image_size['height'] <= $soft_height - 1 || $image_size['height'] >= $soft_height + 1  ) {
+		if ( $image_size['height'] <= $soft_height - 2 || $image_size['height'] >= $soft_height + 2  ) {
 			unset( $default_sizes[$key] );
 		}
 	}

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -62,7 +62,8 @@ function tevkori_get_srcset_array( $id, $size ) {
 		// calculate the height we would expect if this is a soft crop given the size width
 		$soft_height = (int) round( $image_size['width'] * $img_height / $img_width );
 
-		if( $image_size['height'] !== $soft_height ) {
+		// If image height varies more than 1px over the expected, throw it out.
+		if ( $image_size['height'] <= $soft_height - 1 || $image_size['height'] >= $soft_height + 1  ) {
 			unset( $default_sizes[$key] );
 		}
 	}


### PR DESCRIPTION
Adjusts the aspect ratio check in `tevkori_get_srcset_array()` to account for rounding variance. Same as the issue fixed in 4314d38.

Fixes #53 (props @side777)