### PR TITLE
Add Plugin URI to readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,6 +7,7 @@ Tested up to: 4.1
 Stable tag: 2.1.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+Plugin URI: https://github.com/ResponsiveImagesCG/wp-tevko-responsive-images
 
 Bringing automatic default responsive images to WordPress.
 


### PR DESCRIPTION
Via a suggestion at WordCamp St. Louis from @ipstenu, who is on the plugin review team for WordPress.org.