### PR TITLE
Check if wp.media exists before running JS

### DIFF
--- a/js/wp-tevko-responsive-images.js
+++ b/js/wp-tevko-responsive-images.js
@@ -5,42 +5,45 @@
   /**
    * Recalculate srcset attribute after an image-update event
    */
-  wp.media.events.on( 'editor:image-update', function( args ) {
-    // arguments[0] = { Editor, image, metadata }
-	  var image = args.image,
-			metadata = args.metadata,
-			srcsetGroup = [],
-			srcset = '',
-      sizes = '';
+  if ( wp.media ) {
+    wp.media.events.on( 'editor:image-update', function( args ) {
+      // arguments[0] = { Editor, image, metadata }
+  	  var image = args.image,
+  			metadata = args.metadata,
+  			srcsetGroup = [],
+  			srcset = '',
+        sizes = '';
 
-    // if the image url has changed, recalculate srcset attributes
-    if ( metadata && metadata.url !== metadata.originalUrl ) {
-      // we need to get the postdata for the image because
-      // the sizes array isn't passed into the editor
-      var imagePostData = new wp.media.model.PostImage( metadata ),
-        crops = imagePostData.attachment.attributes.sizes;
+      // if the image url has changed, recalculate srcset attributes
+      if ( metadata && metadata.url !== metadata.originalUrl ) {
+        // we need to get the postdata for the image because
+        // the sizes array isn't passed into the editor
+        var imagePostData = new wp.media.model.PostImage( metadata ),
+          crops = imagePostData.attachment.attributes.sizes;
 
-      // grab all the sizes that match our target ratio and add them to our srcset array
-      _.each(crops, function(size){
-        var softHeight = Math.round( size.width * metadata.height / metadata.width );
+        // grab all the sizes that match our target ratio and add them to our srcset array
+        _.each(crops, function(size){
+          var softHeight = Math.round( size.width * metadata.height / metadata.width );
 
-        // If the height is within 1 integer of the expected height, let it pass.
-        if ( size.height >= softHeight - 1 && size.height <= softHeight + 1  ) {
-          srcsetGroup.push(size.url + ' ' + size.width + 'w');
-        }
-      });
+          // If the height is within 1 integer of the expected height, let it pass.
+          if ( size.height >= softHeight - 1 && size.height <= softHeight + 1  ) {
+            srcsetGroup.push(size.url + ' ' + size.width + 'w');
+          }
+        });
 
-      // convert the srcsetGroup array to our srcset value
-      srcset = srcsetGroup.join(', ');
-      sizes = '(max-width: ' + metadata.width + 'px) 100vw, ' + metadata.width + 'px';
+        // convert the srcsetGroup array to our srcset value
+        srcset = srcsetGroup.join(', ');
+        sizes = '(max-width: ' + metadata.width + 'px) 100vw, ' + metadata.width + 'px';
 
-      // update the srcset attribute of our image
-      image.setAttribute( 'srcset', srcset );
+        // update the srcset attribute of our image
+        image.setAttribute( 'srcset', srcset );
 
-      // update the sizes attribute of our image
-      image.setAttribute( 'data-sizes', sizes );
-    }
+        // update the sizes attribute of our image
+        image.setAttribute( 'data-sizes', sizes );
+      }
 
-  });
+    });    
+  }
+
 
 })();


### PR DESCRIPTION
This fixes and issue where post.php or post-new.php is used without loading wp.media, as is the case when adding Advanced Custom Fields field groups, resulting in get the following JS error:

```
Uncaught TypeError: Cannot read property 'events' of undefined
/wordpress/wp-content/plugins/ricg-responsive-images/js/wp-tevko-responsive-images.js?ver=2.0.0 line 8
```

See details in this thread on the WP.org support forums:
https://wordpress.org/support/topic/bug-v211-uncaught-typeerror?replies=9#post-6704725