### PR TITLE
Add srcset attribute to gallery images

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ function custom_theme_setup() {
 }
 add_action( 'after_setup_theme', 'custom_theme_setup' );
 ```
+---
 
 ####tevkori_get_sizes( $id, $size, $args )
 

--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,7 @@ We use a hook because if you attempt to dequeue a script before it's enqueued, w
 
 ##Changelog
 
+- Improved performance of `get_srcset_array`
 - Added smart sizes option (available by adding hook to functions.php)
 
 **2.2.1**

--- a/readme.md
+++ b/readme.md
@@ -111,9 +111,13 @@ The only external dependency included in this plugin is Picturefill - v2.3.0. If
 
 ##Version
 
-2.2.0
+2.2.1
 
 ##Changelog
+
+- JS patch for wordpress
+
+**2.2.0**
 
 - The mandatory sizes attribute is now included on all images
 - Updated to Picturefill v2.3.0

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,18 @@ No configuration is needed! Just install the plugin and enjoy automatic responsi
 
 This plugin includes several functions that can be used by theme and plugin developers in templates.
 
+###Advanced Image Compression
+
+**This is an experimental feature, if used, please provide us with feedback!**
+
+This feature turns on advanced compression, which will deliver higher quality images at a smaller file size. To enable, place the following code in your `functions.php` file - 
+```
+function custom_theme_setup() {
+	add_theme_support( 'advanced-image-compression' );
+}
+add_action( 'after_setup_theme', 'custom_theme_setup' );
+```
+
 ####tevkori_get_sizes( $id, $size, $args )
 
 Returns a valid source size value for use in a 'sizes' attribute. The parameters include the ID of the image, the default size of the image, and an array or string containing of size information. The ID parameter is required. [Link](https://github.com/ResponsiveImagesCG/wp-tevko-responsive-images/blob/master/wp-tevko-responsive-images.php#L28)
@@ -119,9 +131,13 @@ We use a hook because if you attempt to dequeue a script before it's enqueued, w
 
 ##Version
 
-2.2.1
+2.3.0
 
 ##Changelog
+
+- Added smart sizes option (available by adding hook to functions.php)
+
+**2.2.1**
 
 - JS patch for wordpress
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://app.etapestry.com/hosted/BoweryResidentsCommittee/OnlineDon
 Tags: Responsive, Images, Responsive Images, SRCSET, Picturefill
 Requires at least: 4.1
 Tested up to: 4.1
-Stable tag: 2.2.0
+Stable tag: 2.2.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt
 
@@ -24,6 +24,9 @@ This plugin works by including all available image sizes for each image upload. 
 2. Activate the plugin through the 'Plugins' menu in WordPress
 
 == Changelog ==
+= 2.2.1 =
+* Patch fixing missing javascript error
+
 = 2.2.0 =
 * The mandatory sizes attribute is now included on all images
 * Updated to Picturefill v2.3.0

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -9,7 +9,7 @@ defined('ABSPATH') or die("No script kiddies please!");
  * Plugin Name:       RICG Responsive Images
  * Plugin URI:        http://www.smashingmagazine.com/2015/02/24/ricg-responsive-images-for-wordpress/
  * Description:       Bringing automatic default responsive images to wordpress
- * Version:           2.2.0
+ * Version:           2.2.1
  * Author:            The RICG
  * Author URI:        http://responsiveimages.org/
  * License:           GPL-2.0+


### PR DESCRIPTION
Currently gallery images don't get a ```srcset``` attribute. By using the ```wp_get_attachment_image_attributes``` filter the ```srcset``` attribute will be added to both post thumbnails and gallery images.

Note: In the function that I replaced, either the comment (```data-sizes```) or the attribute name (```sizes``) in the code was wrong...
```
// Build the data-sizes attribute if sizes were returned.
if ( $sizes ) {
	$sizes = 'sizes="' . $sizes . '"';
}
```
Elsewhere in the code you use ```data-sizes``` so I guess the attribute name is wrong, but I don't understand why. I use ```data-sizes``` in my own code for the Lazysizes plugin, but Picturefill doesn't do anything with ```data-``` attributes, right? Anyway, I kept the mistake in the code. I can always rebase when it's fixed on master.