### PR TITLE
Use smallest image from srcset as value for src

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ function custom_theme_setup() {
 }
 add_action( 'after_setup_theme', 'custom_theme_setup' );
 ```
+---
 
 ####tevkori_get_sizes( $id, $size, $args )
 

--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,7 @@ We use a hook because if you attempt to dequeue a script before it's enqueued, w
 
 ##Changelog
 
+- Improved performance of `get_srcset_array`
 - Added smart sizes option (available by adding hook to functions.php)
 
 **2.2.1**

--- a/readme.md
+++ b/readme.md
@@ -111,9 +111,13 @@ The only external dependency included in this plugin is Picturefill - v2.3.0. If
 
 ##Version
 
-2.2.0
+2.2.1
 
 ##Changelog
+
+- JS patch for wordpress
+
+**2.2.0**
 
 - The mandatory sizes attribute is now included on all images
 - Updated to Picturefill v2.3.0

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,18 @@ No configuration is needed! Just install the plugin and enjoy automatic responsi
 
 This plugin includes several functions that can be used by theme and plugin developers in templates.
 
+###Advanced Image Compression
+
+**This is an experimental feature, if used, please provide us with feedback!**
+
+This feature turns on advanced compression, which will deliver higher quality images at a smaller file size. To enable, place the following code in your `functions.php` file - 
+```
+function custom_theme_setup() {
+	add_theme_support( 'advanced-image-compression' );
+}
+add_action( 'after_setup_theme', 'custom_theme_setup' );
+```
+
 ####tevkori_get_sizes( $id, $size, $args )
 
 Returns a valid source size value for use in a 'sizes' attribute. The parameters include the ID of the image, the default size of the image, and an array or string containing of size information. The ID parameter is required. [Link](https://github.com/ResponsiveImagesCG/wp-tevko-responsive-images/blob/master/wp-tevko-responsive-images.php#L28)
@@ -119,9 +131,13 @@ We use a hook because if you attempt to dequeue a script before it's enqueued, w
 
 ##Version
 
-2.2.1
+2.3.0
 
 ##Changelog
+
+- Added smart sizes option (available by adding hook to functions.php)
+
+**2.2.1**
 
 - JS patch for wordpress
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://app.etapestry.com/hosted/BoweryResidentsCommittee/OnlineDon
 Tags: Responsive, Images, Responsive Images, SRCSET, Picturefill
 Requires at least: 4.1
 Tested up to: 4.1
-Stable tag: 2.2.0
+Stable tag: 2.2.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt
 
@@ -24,6 +24,9 @@ This plugin works by including all available image sizes for each image upload. 
 2. Activate the plugin through the 'Plugins' menu in WordPress
 
 == Changelog ==
+= 2.2.1 =
+* Patch fixing missing javascript error
+
 = 2.2.0 =
 * The mandatory sizes attribute is now included on all images
 * Updated to Picturefill v2.3.0

--- a/tests/test-suite.php
+++ b/tests/test-suite.php
@@ -137,11 +137,11 @@ class SampleTest extends WP_UnitTestCase {
 		$filename_base = substr( $image['file'], 0, strrpos($image['file'], '.png') );
 
 		$expected = array(
-			'http://example.org/wp-content/uploads/' . $year_month = date('Y/m') . '/'
+			$image['sizes']['medium']['width'] => 'http://example.org/wp-content/uploads/' . $year_month = date('Y/m') . '/'
 				. $image['sizes']['medium']['file'] . ' ' . $image['sizes']['medium']['width'] . 'w',
-			'http://example.org/wp-content/uploads/' . $year_month = date('Y/m') . '/'
+			$image['sizes']['large']['width'] => 'http://example.org/wp-content/uploads/' . $year_month = date('Y/m') . '/'
 				. $image['sizes']['large']['file'] . ' ' . $image['sizes']['large']['width'] . 'w',
-			'http://example.org/wp-content/uploads/' . $image['file'] . ' ' . $image['width'] .'w'
+			$image['width'] => 'http://example.org/wp-content/uploads/' . $image['file'] . ' ' . $image['width'] .'w'
 		);
 
 		$this->assertSame( $expected, $sizes );
@@ -156,7 +156,7 @@ class SampleTest extends WP_UnitTestCase {
 
 		$year_month = date('Y/m');
 		$expected = array(
-			'http://example.org/wp-content/uploads/' . $year_month = date('Y/m') . '/'
+			$image['sizes']['thumbnail']['width'] => 'http://example.org/wp-content/uploads/' . $year_month = date('Y/m') . '/'
 				. $image['sizes']['thumbnail']['file'] . ' ' . $image['sizes']['thumbnail']['width'] . 'w',
 		);
 

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -9,7 +9,7 @@ defined('ABSPATH') or die("No script kiddies please!");
  * Plugin Name:       RICG Responsive Images
  * Plugin URI:        http://www.smashingmagazine.com/2015/02/24/ricg-responsive-images-for-wordpress/
  * Description:       Bringing automatic default responsive images to wordpress
- * Version:           2.2.0
+ * Version:           2.2.1
  * Author:            The RICG
  * Author URI:        http://responsiveimages.org/
  * License:           GPL-2.0+


### PR DESCRIPTION
This PR is meant as code example for ticket https://github.com/ResponsiveImagesCG/wp-tevko-responsive-images/issues/78

Notes:
- I used my gallery-images branch (see PR https://github.com/ResponsiveImagesCG/wp-tevko-responsive-images/pull/73) as base
- I cherry-picked the commits from https://github.com/ResponsiveImagesCG/wp-tevko-responsive-images/pull/82 (performance improvement)
- The relevant commit is "Use smallest image from srcset as value for src" (b6d39bb)
- ```tevkori_get_srcset_string()``` isn't used internally anymore but I left it in there so it can be used as template tag
- I didn't update the JS that handles the image editor
- I didn't run or look into unit tests