### PR TITLE
For discussion: ImageMagick biz

### DIFF
--- a/class-respimg.php
+++ b/class-respimg.php
@@ -1,0 +1,245 @@
+<?php
+
+	/**
+	 * hacked up version of php-respimg <https://github.com/nwtn/php-respimg>
+	 *
+	 * @package wp-respimg
+	 * @version 0.0.1
+	 */
+
+	if (class_exists('Imagick')) {
+		class RespimgImagick extends Imagick { }
+	} else {
+		class RespimgImagick { }
+	}
+
+
+	/**
+	 * An Imagick extension to provide better (higher quality, lower file size) image resizes.
+	 *
+	 * This class extends Imagick (<http://php.net/manual/en/book.imagick.php>) based on
+	 * research into optimal image resizing techniques (<https://github.com/nwtn/image-resize-tests>).
+	 *
+	 * Using these methods with their default settings should provide image resizing that is
+	 * visually indistinguishable from Photoshop’s “Save for Web…”, but at lower file sizes.
+	 *
+	 * @author		David Newton <david@davidnewton.ca>
+	 * @copyright	2015 David Newton
+	 * @license		https://raw.githubusercontent.com/nwtn/php-respimg/master/LICENSE MIT
+	 * @version		1.0.0
+	 */
+
+	class Respimg extends RespimgImagick {
+
+		/**
+		 * Resizes the image using smart defaults for high quality and low file size.
+		 *
+		 * This function is basically equivalent to:
+		 *
+		 * $optim == true: `mogrify -path OUTPUT_PATH -filter Triangle -define filter:support=2.0 -thumbnail OUTPUT_WIDTH -unsharp 0.25x0.08+8.3+0.045 -dither None -posterize 136 -quality 82 -define jpeg:fancy-upsampling=off -define png:compression-filter=5 -define png:compression-level=9 -define png:compression-strategy=1 -define png:exclude-chunk=all -interlace none -colorspace sRGB INPUT_PATH`
+		 *
+		 * $optim == false: `mogrify -path OUTPUT_PATH -filter Triangle -define filter:support=2.0 -thumbnail OUTPUT_WIDTH -unsharp 0.25x0.25+8+0.065 -dither None -posterize 136 -quality 82 -define jpeg:fancy-upsampling=off -define png:compression-filter=5 -define png:compression-level=9 -define png:compression-strategy=1 -define png:exclude-chunk=all -interlace none -colorspace sRGB -strip INPUT_PATH`
+		 *
+		 * @access	public
+		 *
+		 * @param	integer	$columns		The number of columns in the output image. 0 = maintain aspect ratio based on $rows.
+		 * @param	integer	$rows			The number of rows in the output image. 0 = maintain aspect ratio based on $columns.
+		 * @param	bool	$optim			Whether you intend to perform optimization on the resulting image. Note that setting this to `true` doesn’t actually perform any optimization.
+		 */
+
+		public function smartResize($columns, $rows, $optim = false) {
+
+			$this->setOption('filter:support', '2.0');
+			$this->thumbnailImage($columns, $rows, false, false, Imagick::FILTER_TRIANGLE);
+			if ($optim) {
+				$this->unsharpMaskImage(0.25, 0.08, 8.3, 0.045);
+			} else {
+				$this->unsharpMaskImage(0.25, 0.25, 8, 0.065);
+			}
+			$this->posterizeImage(136, false);
+			$this->setImageCompressionQuality(82);
+			$this->setOption('jpeg:fancy-upsampling', 'off');
+			$this->setOption('png:compression-filter', '5');
+			$this->setOption('png:compression-level', '9');
+			$this->setOption('png:compression-strategy', '1');
+			$this->setOption('png:exclude-chunk', 'all');
+			$this->setInterlaceScheme(Imagick::INTERLACE_NO);
+			$this->setColorspace(Imagick::COLORSPACE_SRGB);
+			if (!$optim) {
+				$this->stripImage();
+			}
+
+		}
+
+
+		/**
+		 * Changes the size of an image to the given dimensions and removes any associated profiles.
+		 *
+		 * `thumbnailImage` changes the size of an image to the given dimensions and
+		 * removes any associated profiles.  The goal is to produce small low cost
+		 * thumbnail images suited for display on the Web.
+		 *
+		 * With the original Imagick thumbnailImage implementation, there is no way to choose a
+		 * resampling filter. This class recreates Imagick’s C implementation and adds this
+		 * additional feature.
+		 *
+		 * Note: <https://github.com/mkoppanen/imagick/issues/90> has been filed for this issue.
+		 *
+		 * @access	public
+		 *
+		 * @param	integer	$columns		The number of columns in the output image. 0 = maintain aspect ratio based on $rows.
+		 * @param	integer	$rows			The number of rows in the output image. 0 = maintain aspect ratio based on $columns.
+		 * @param	bool	$bestfit		Treat $columns and $rows as a bounding box in which to fit the image.
+		 * @param	bool	$fill			Fill in the bounding box with the background colour.
+		 * @param	integer	$filter			The resampling filter to use. Refer to the list of filter constants at <http://php.net/manual/en/imagick.constants.php>.
+		 *
+		 * @return	bool	Indicates whether the operation was performed successfully.
+		 */
+
+		public function thumbnailImage($columns, $rows, $bestfit = false, $fill = false, $filter = Imagick::FILTER_TRIANGLE) {
+
+			// sample factor; defined in original ImageMagick thumbnailImage function
+			// the scale to which the image should be resized using the `sample` function
+			$SampleFactor = 5;
+
+			// filter whitelist
+			$filters = array(
+				Imagick::FILTER_POINT,
+				Imagick::FILTER_BOX,
+				Imagick::FILTER_TRIANGLE,
+				Imagick::FILTER_HERMITE,
+				Imagick::FILTER_HANNING,
+				Imagick::FILTER_HAMMING,
+				Imagick::FILTER_BLACKMAN,
+				Imagick::FILTER_GAUSSIAN,
+				Imagick::FILTER_QUADRATIC,
+				Imagick::FILTER_CUBIC,
+				Imagick::FILTER_CATROM,
+				Imagick::FILTER_MITCHELL,
+				Imagick::FILTER_LANCZOS,
+				Imagick::FILTER_BESSEL,
+				Imagick::FILTER_SINC
+			);
+
+			// Parse parameters given to function
+			$columns = (double) ($columns);
+			$rows = (double) ($rows);
+			$bestfit = (bool) $bestfit;
+			$fill = (bool) $fill;
+
+			// We can’t resize to (0,0)
+			if ($rows < 1 && $columns < 1) {
+				return false;
+			}
+
+			// Set a default filter if an acceptable one wasn’t passed
+			if (!in_array($filter, $filters)) {
+				$filter = Imagick::FILTER_TRIANGLE;
+			}
+
+			// figure out the output width and height
+			$width = (double) $this->getImageWidth();
+			$height = (double) $this->getImageHeight();
+			$new_width = $columns;
+			$new_height = $rows;
+
+			$x_factor = $columns / $width;
+			$y_factor = $rows / $height;
+			if ($rows < 1) {
+				$new_height = round($x_factor * $height);
+			} elseif ($columns < 1) {
+				$new_width = round($y_factor * $width);
+			}
+
+			// if bestfit is true, the new_width/new_height of the image will be different than
+			// the columns/rows parameters; those will define a bounding box in which the image will be fit
+			if ($bestfit && $x_factor > $y_factor) {
+				$x_factor = $y_factor;
+				$new_width = round($y_factor * $width);
+			} elseif ($bestfit && $y_factor > $x_factor) {
+				$y_factor = $x_factor;
+				$new_height = round($x_factor * $height);
+			}
+			if ($new_width < 1) {
+				$new_width = 1;
+			}
+			if ($new_height < 1) {
+				$new_height = 1;
+			}
+
+			// if we’re resizing the image to more than about 1/3 it’s original size
+			// then just use the resize function
+			if (($x_factor * $y_factor) > 0.1) {
+				$this->resizeImage($new_width, $new_height, $filter, 1);
+
+			// if we’d be using sample to scale to smaller than 128x128, just use resize
+			} elseif ((($SampleFactor * $new_width) < 128) || (($SampleFactor * $new_height) < 128)) {
+					$this->resizeImage($new_width, $new_height, $filter, 1);
+
+			// otherwise, use sample first, then resize
+			} else {
+				$this->sampleImage($SampleFactor * $new_width, $SampleFactor * $new_height);
+				$this->resizeImage($new_width, $new_height, $filter, 1);
+			}
+
+			// if the alpha channel is not defined, make it opaque
+			if ($this->getImageAlphaChannel() == Imagick::ALPHACHANNEL_UNDEFINED) {
+				$this->setImageAlphaChannel(Imagick::ALPHACHANNEL_OPAQUE);
+			}
+
+			// set the image’s bit depth to 8 bits
+			$this->setImageDepth(8);
+
+			// turn off interlacing
+			$this->setInterlaceScheme(Imagick::INTERLACE_NO);
+
+			// Strip all profiles except color profiles.
+			foreach ($this->getImageProfiles('*', true) as $key => $value) {
+				if ($key != 'icc' && $key != 'icm') {
+					$this->removeImageProfile($key);
+				}
+			}
+
+			if (method_exists($this, 'deleteImageProperty')) {
+				$this->deleteImageProperty('comment');
+				$this->deleteImageProperty('Thumb::URI');
+				$this->deleteImageProperty('Thumb::MTime');
+				$this->deleteImageProperty('Thumb::Size');
+				$this->deleteImageProperty('Thumb::Mimetype');
+				$this->deleteImageProperty('software');
+				$this->deleteImageProperty('Thumb::Image::Width');
+				$this->deleteImageProperty('Thumb::Image::Height');
+				$this->deleteImageProperty('Thumb::Document::Pages');
+			} else {
+				$this->setImageProperty('comment', '');
+				$this->setImageProperty('Thumb::URI', '');
+				$this->setImageProperty('Thumb::MTime', '');
+				$this->setImageProperty('Thumb::Size', '');
+				$this->setImageProperty('Thumb::Mimetype', '');
+				$this->setImageProperty('software', '');
+				$this->setImageProperty('Thumb::Image::Width', '');
+				$this->setImageProperty('Thumb::Image::Height', '');
+				$this->setImageProperty('Thumb::Document::Pages', '');
+			}
+
+			// In case user wants to fill use extent for it rather than creating a new canvas
+			// …fill out the bounding box
+			if ($bestfit && $fill && ($new_width != $columns || $new_height != $rows)) {
+				$extent_x = 0;
+				$extent_y = 0;
+
+				if ($columns > $new_width) {
+					$extent_x = ($columns - $new_width) / 2;
+				}
+				if ($rows > $new_height) {
+					$extent_y = ($rows - $new_height) / 2;
+				}
+
+				$this->extentImage($columns, $rows, 0 - $extent_x, $extent_y);
+			}
+
+			return true;
+
+		}
+
+	}

--- a/class-wp-image-editor-respimg.php
+++ b/class-wp-image-editor-respimg.php
@@ -88,7 +88,11 @@
 			}
 
 			try {
-				$this->image->smartResize( $dst_w, $dst_h, false );
+				if ($this->mime_type === 'image/gif') {
+					$this->image->scaleImage( $dst_w, $dst_h );
+				} else {
+					$this->image->smartResize( $dst_w, $dst_h, false );
+				}
 			}
 			catch ( Exception $e ) {
 				return new WP_Error( 'image_resize_error', $e->getMessage() );
@@ -197,7 +201,11 @@
 					if ( ! $dst_h )
 						$dst_h = $src_h;
 
-					$this->image->smartResize( $dst_w, $dst_h, false );
+					if ($this->mime_type === 'image/gif') {
+						$this->image->scaleImage( $dst_w, $dst_h );
+					} else {
+						$this->image->smartResize( $dst_w, $dst_h, false );
+					}
 					return $this->update_size();
 				}
 			}

--- a/class-wp-image-editor-respimg.php
+++ b/class-wp-image-editor-respimg.php
@@ -1,0 +1,210 @@
+<?php
+
+	/**
+	 * WordPress Respimg Imagick Image Editor
+	 *
+	 * @package wp-respimg
+	 * @version 0.0.1
+	 */
+
+	require_once ABSPATH . WPINC . '/class-wp-image-editor.php';
+	require_once ABSPATH . WPINC . '/class-wp-image-editor-imagick.php';
+
+	/**
+	 * WordPress Image Editor Class for Image Manipulation through Imagick PHP Module with php-respimg
+	 *
+	 * @package wp-respimg
+	 * @uses WP_Image_Editor_Imagick Extends class
+	 */
+	class WP_Image_Editor_Respimg extends WP_Image_Editor_Imagick {
+
+		/**
+		 * Loads image from $this->file into new Respimg Object.
+		 *
+		 * @access protected
+		 *
+		 * @return boolean|WP_Error True if loaded; WP_Error on failure.
+		 */
+		public function load() {
+			if ( $this->image instanceof Respimg )
+				return true;
+
+			if ( ! is_file( $this->file ) && ! preg_match( '|^https?://|', $this->file ) )
+				return new WP_Error( 'error_loading_image', __('File doesn&#8217;t exist?'), $this->file );
+
+			/** This filter is documented in wp-includes/class-wp-image-editor-imagick.php */
+			// Even though Imagick uses less PHP memory than GD, set higher limit for users that have low PHP.ini limits
+			@ini_set( 'memory_limit', apply_filters( 'image_memory_limit', WP_MAX_MEMORY_LIMIT ) );
+
+			try {
+				$this->image = new Respimg( $this->file );
+
+				if( ! $this->image->valid() )
+					return new WP_Error( 'invalid_image', __('File is not an image.'), $this->file);
+
+				// Select the first frame to handle animated images properly
+				if ( is_callable( array( $this->image, 'setIteratorIndex' ) ) )
+					$this->image->setIteratorIndex(0);
+
+				$this->mime_type = $this->get_mime_type( $this->image->getImageFormat() );
+			}
+			catch ( Exception $e ) {
+				return new WP_Error( 'invalid_image', $e->getMessage(), $this->file );
+			}
+
+			$updated_size = $this->update_size();
+			if ( is_wp_error( $updated_size ) ) {
+				return $updated_size;
+			}
+
+			return $this->set_quality();
+		}
+
+		/**
+		 * Resizes current image.
+		 *
+		 * At minimum, either a height or width must be provided.
+		 * If one of the two is set to null, the resize will
+		 * maintain aspect ratio according to the provided dimension.
+		 *
+		 * @access public
+		 *
+		 * @param  int|null $max_w Image width.
+		 * @param  int|null $max_h Image height.
+		 * @param  boolean  $crop
+		 * @return boolean|WP_Error
+		 */
+		public function resize( $max_w, $max_h, $crop = false ) {
+			if ( ( $this->size['width'] == $max_w ) && ( $this->size['height'] == $max_h ) )
+				return true;
+
+			$dims = image_resize_dimensions( $this->size['width'], $this->size['height'], $max_w, $max_h, $crop );
+			if ( ! $dims )
+				return new WP_Error( 'error_getting_dimensions', __('Could not calculate resized image dimensions') );
+			list( $dst_x, $dst_y, $src_x, $src_y, $dst_w, $dst_h, $src_w, $src_h ) = $dims;
+
+			if ( $crop ) {
+				return $this->crop( $src_x, $src_y, $src_w, $src_h, $dst_w, $dst_h );
+			}
+
+			try {
+				$this->image->smartResize( $dst_w, $dst_h, false );
+			}
+			catch ( Exception $e ) {
+				return new WP_Error( 'image_resize_error', $e->getMessage() );
+			}
+
+			return $this->update_size( $dst_w, $dst_h );
+		}
+
+		/**
+		 * Resize multiple images from a single source.
+		 *
+		 * @access public
+		 *
+		 * @param array $sizes {
+		 *     An array of image size arrays. Default sizes are 'small', 'medium', 'large'.
+		 *
+		 *     Either a height or width must be provided.
+		 *     If one of the two is set to null, the resize will
+		 *     maintain aspect ratio according to the provided dimension.
+		 *
+		 *     @type array $size {
+		 *         @type int  ['width']  Optional. Image width.
+		 *         @type int  ['height'] Optional. Image height.
+		 *         @type bool $crop   Optional. Whether to crop the image. Default false.
+		 *     }
+		 * }
+		 * @return array An array of resized images' metadata by size.
+		 */
+		public function multi_resize( $sizes ) {
+			$metadata = array();
+			$orig_size = $this->size;
+			$orig_image = clone $this->image;
+
+			foreach ( $sizes as $size => $size_data ) {
+				if ( ! $this->image )
+					$this->image = clone $orig_image;
+
+				if ( ! isset( $size_data['width'] ) && ! isset( $size_data['height'] ) ) {
+					continue;
+				}
+
+				if ( ! isset( $size_data['width'] ) ) {
+					$size_data['width'] = null;
+				}
+				if ( ! isset( $size_data['height'] ) ) {
+					$size_data['height'] = null;
+				}
+
+				if ( ! isset( $size_data['crop'] ) ) {
+					$size_data['crop'] = false;
+				}
+
+				$resize_result = $this->resize( $size_data['width'], $size_data['height'], $size_data['crop'] );
+				$duplicate = ( ( $orig_size['width'] == $size_data['width'] ) && ( $orig_size['height'] == $size_data['height'] ) );
+
+				if ( ! is_wp_error( $resize_result ) && ! $duplicate ) {
+					$resized = $this->_save( $this->image );
+
+					$this->image->clear();
+					$this->image->destroy();
+					$this->image = null;
+
+					if ( ! is_wp_error( $resized ) && $resized ) {
+						unset( $resized['path'] );
+						$metadata[$size] = $resized;
+					}
+				}
+
+				$this->size = $orig_size;
+			}
+
+			$this->image = $orig_image;
+
+			return $metadata;
+		}
+
+		/**
+		 * Crops Image.
+		 *
+		 * @access public
+		 *
+		 * @param int $src_x The start x position to crop from.
+		 * @param int $src_y The start y position to crop from.
+		 * @param int $src_w The width to crop.
+		 * @param int $src_h The height to crop.
+		 * @param int $dst_w Optional. The destination width.
+		 * @param int $dst_h Optional. The destination height.
+		 * @param boolean $src_abs Optional. If the source crop points are absolute.
+		 * @return boolean|WP_Error
+		 */
+		public function crop( $src_x, $src_y, $src_w, $src_h, $dst_w = null, $dst_h = null, $src_abs = false ) {
+			if ( $src_abs ) {
+				$src_w -= $src_x;
+				$src_h -= $src_y;
+			}
+
+			try {
+				$this->image->cropImage( $src_w, $src_h, $src_x, $src_y );
+				$this->image->setImagePage( $src_w, $src_h, 0, 0);
+
+				if ( $dst_w || $dst_h ) {
+					// If destination width/height isn't specified, use same as
+					// width/height from source.
+					if ( ! $dst_w )
+						$dst_w = $src_w;
+					if ( ! $dst_h )
+						$dst_h = $src_h;
+
+					$this->image->smartResize( $dst_w, $dst_h, false );
+					return $this->update_size();
+				}
+			}
+			catch ( Exception $e ) {
+				return new WP_Error( 'image_crop_error', $e->getMessage() );
+			}
+			return $this->update_size();
+		}
+
+	}

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -1,5 +1,8 @@
 <?php
 defined('ABSPATH') or die("No script kiddies please!");
+require_once plugin_dir_path(__FILE__) . 'class-respimg.php';
+require_once plugin_dir_path(__FILE__) . 'class-wp-image-editor-respimg.php';
+
 /**
  * @link              https://github.com/ResponsiveImagesCG/wp-tevko-responsive-images
  * @since             2.0.0
@@ -299,3 +302,15 @@ function tevkori_filter_content_sizes( $content ) {
 	return $content;
 }
 add_filter('the_content', 'tevkori_filter_content_sizes');
+
+
+/**
+ * Filter to add php-respimg as an image editor
+ *
+ * @return array editors
+ **/
+function tevkori_wp_image_editors($editors) {
+	array_unshift($editors, 'WP_Image_Editor_Respimg');
+	return $editors;
+}
+add_filter('wp_image_editors', 'tevkori_wp_image_editors');


### PR DESCRIPTION
See <http://ircbot.responsiveimages.org/bot/log/respimg/2015-04-20#T125175>.

Basically this will use a different set of ImageMagick commands than what WordPress uses by default for resizing images. In most cases it should produces files that look identical to resizing done with Photoshop’s “Save for Web”, but at smaller file sizes than either Photoshop or WordPress’s default options.