### PR TITLE
Refactor the Plugin JS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[{.jshintrc,*.json,*.yml}]
+indent_style = space
+indent_size = 2
+
+[{*.txt,wp-config-sample.php}]
+end_of_line = crlf

--- a/js/wp-tevko-responsive-images.js
+++ b/js/wp-tevko-responsive-images.js
@@ -11,15 +11,11 @@
 			var image = args.image,
 				metadata = args.metadata;
 
-			// if the image url has changed, recalculate srcset attributes
+			// If the image url has changed, recalculate srcset attributes.
 			if ( metadata && metadata.url !== metadata.originalUrl ) {
-				// we need to get the postdata for the image because
-				// the sizes array isn't passed into the editor
-
-				// Update the srcset attribute
+				// Update the srcset attribute.
 				updateSrcset( image, metadata );
-
-				// Update the sizes attribute
+				// Update the sizes attribute.
 				updateSizes( image, metadata );
 			}
 
@@ -49,7 +45,7 @@
 
 		var sizes = '(max-width: ' + metadata.width + 'px) 100vw, ' + metadata.width + 'px';
 
-		// update the sizes attribute of our image
+		// Update the sizes attribute of our image.
 		image.setAttribute( 'data-sizes', sizes );
 	}
 

--- a/js/wp-tevko-responsive-images.js
+++ b/js/wp-tevko-responsive-images.js
@@ -9,40 +9,48 @@
     wp.media.events.on( 'editor:image-update', function( args ) {
       // arguments[0] = { Editor, image, metadata }
   	  var image = args.image,
-  			metadata = args.metadata,
-  			srcsetGroup = [],
-  			srcset = '',
-        sizes = '';
+  			metadata = args.metadata;
 
       // if the image url has changed, recalculate srcset attributes
       if ( metadata && metadata.url !== metadata.originalUrl ) {
         // we need to get the postdata for the image because
         // the sizes array isn't passed into the editor
-        var imagePostData = new wp.media.model.PostImage( metadata ),
-          crops = imagePostData.attachment.attributes.sizes;
 
-        // grab all the sizes that match our target ratio and add them to our srcset array
-        _.each(crops, function(size){
-          var softHeight = Math.round( size.width * metadata.height / metadata.width );
+        // Update the srcset attribute
+        updateSrcset( image, metadata );
 
-          // If the height is within 1 integer of the expected height, let it pass.
-          if ( size.height >= softHeight - 1 && size.height <= softHeight + 1  ) {
-            srcsetGroup.push(size.url + ' ' + size.width + 'w');
-          }
-        });
-
-        // convert the srcsetGroup array to our srcset value
-        srcset = srcsetGroup.join(', ');
-        sizes = '(max-width: ' + metadata.width + 'px) 100vw, ' + metadata.width + 'px';
-
-        // update the srcset attribute of our image
-        image.setAttribute( 'srcset', srcset );
-
-        // update the sizes attribute of our image
-        image.setAttribute( 'data-sizes', sizes );
+        // Update the sizes attribute
+        updateSizes( image, metadata );
       }
 
-    });    
+    });
+  }
+
+  /**
+   * Update the srcet attribute on an image in the editor
+   */
+  var updateSrcset = function( image, metadata ) {
+
+    var data = {
+      action: 'tevkori_ajax_srcset',
+      postID: metadata.attachment_id,
+      size: metadata.size
+    };
+
+    jQuery.post( ajaxurl, data, function( response ) {
+      image.setAttribute( 'srcset', response );
+    });
+  }
+
+  /**
+   * Update the data-sizes attribute on an image in the editor
+   */
+  var updateSizes = function( image, metadata ) {
+    
+    var sizes = '(max-width: ' + metadata.width + 'px) 100vw, ' + metadata.width + 'px';
+
+    // update the sizes attribute of our image
+    image.setAttribute( 'data-sizes', sizes );
   }
 
 

--- a/js/wp-tevko-responsive-images.js
+++ b/js/wp-tevko-responsive-images.js
@@ -2,56 +2,56 @@
 
 (function() {
 
-  /**
-   * Recalculate srcset attribute after an image-update event
-   */
-  if ( wp.media ) {
-    wp.media.events.on( 'editor:image-update', function( args ) {
-      // arguments[0] = { Editor, image, metadata }
-  	  var image = args.image,
-  			metadata = args.metadata;
+	/**
+	 * Recalculate srcset attribute after an image-update event
+	 */
+	if ( wp.media ) {
+		wp.media.events.on( 'editor:image-update', function( args ) {
+			// arguments[0] = { Editor, image, metadata }
+			var image = args.image,
+				metadata = args.metadata;
 
-      // if the image url has changed, recalculate srcset attributes
-      if ( metadata && metadata.url !== metadata.originalUrl ) {
-        // we need to get the postdata for the image because
-        // the sizes array isn't passed into the editor
+			// if the image url has changed, recalculate srcset attributes
+			if ( metadata && metadata.url !== metadata.originalUrl ) {
+				// we need to get the postdata for the image because
+				// the sizes array isn't passed into the editor
 
-        // Update the srcset attribute
-        updateSrcset( image, metadata );
+				// Update the srcset attribute
+				updateSrcset( image, metadata );
 
-        // Update the sizes attribute
-        updateSizes( image, metadata );
-      }
+				// Update the sizes attribute
+				updateSizes( image, metadata );
+			}
 
-    });
-  }
+		});
+	}
 
-  /**
-   * Update the srcet attribute on an image in the editor
-   */
-  var updateSrcset = function( image, metadata ) {
+	/**
+	 * Update the srcet attribute on an image in the editor
+	 */
+	var updateSrcset = function( image, metadata ) {
 
-    var data = {
-      action: 'tevkori_ajax_srcset',
-      postID: metadata.attachment_id,
-      size: metadata.size
-    };
+		var data = {
+			action: 'tevkori_ajax_srcset',
+			postID: metadata.attachment_id,
+			size: metadata.size
+		};
 
-    jQuery.post( ajaxurl, data, function( response ) {
-      image.setAttribute( 'srcset', response );
-    });
-  }
+		jQuery.post( ajaxurl, data, function( response ) {
+			image.setAttribute( 'srcset', response );
+		});
+	}
 
-  /**
-   * Update the data-sizes attribute on an image in the editor
-   */
-  var updateSizes = function( image, metadata ) {
-    
-    var sizes = '(max-width: ' + metadata.width + 'px) 100vw, ' + metadata.width + 'px';
+	/**
+	 * Update the data-sizes attribute on an image in the editor
+	 */
+	var updateSizes = function( image, metadata ) {
 
-    // update the sizes attribute of our image
-    image.setAttribute( 'data-sizes', sizes );
-  }
+		var sizes = '(max-width: ' + metadata.width + 'px) 100vw, ' + metadata.width + 'px';
+
+		// update the sizes attribute of our image
+		image.setAttribute( 'data-sizes', sizes );
+	}
 
 
 })();

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -353,7 +353,13 @@ function tevkori_wp_image_editors( $editors ) {
 }
 add_filter( 'wp_image_editors', 'tevkori_wp_image_editors' );
 
-
+/**
+ * Ajax handler for updating the srcset when an image is changed in the editor.
+ *
+ * @since 2.3.0
+ *
+ * @return string A sourcest value.
+ */
 function tevkori_ajax_srcset() {
 
 	// Bail early if no post ID is passed.

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -44,7 +44,7 @@ add_action( 'wp_enqueue_scripts', 'tevkori_get_picturefill' );
  * @return string|bool A valid source size value for use in a 'sizes' attribute or false.
  */
 function tevkori_get_sizes( $id, $size = 'thumbnail', $args = null ) {
-	
+
 	// See which image is being returned and bail if none is found.
 	if ( ! $img = image_downsize( $id, $size ) ) {
 		return false;
@@ -352,3 +352,23 @@ function tevkori_wp_image_editors( $editors ) {
 	return $editors;
 }
 add_filter( 'wp_image_editors', 'tevkori_wp_image_editors' );
+
+
+function tevkori_ajax_srcset() {
+
+	// Bail early if no post ID is passed.
+	if ( ! $postID = $_POST['postID'] ) {
+		return;
+	};
+
+	// Grab the image size being passed from the AJAX request.
+	$size = $_POST['size'];
+
+	// Get the srcset value for our image.
+	$srcset = tevkori_get_srcset( $postID, $size );
+
+	// For AJAX requests, we echo the result and then die.
+	echo $srcset;
+	die();
+}
+add_action( 'wp_ajax_tevkori_ajax_srcset', 'tevkori_ajax_srcset' );


### PR DESCRIPTION
This cleans up the plugin JS by abstracting the logic for updating the `srcset` and `sizes` attributes into their own functions. In order to grab all the available sizes for `srcset` attributes (see #80), I've added an our own AJAX function which will use the plugin internals to retrieve `srcset` values and pass them back to the editor instead of duplicating all of that logic in the JS.