### PR TITLE
Use native wp_send_json to send the output

### DIFF
--- a/js/wp-tevko-responsive-images.js
+++ b/js/wp-tevko-responsive-images.js
@@ -36,7 +36,7 @@
 		jQuery.post( ajaxurl, data, function( response ) {
 			image.setAttribute( 'srcset', response );
 		});
-	}
+	};
 
 	/**
 	 * Update the data-sizes attribute on an image in the editor
@@ -47,7 +47,7 @@
 
 		// Update the sizes attribute of our image.
 		image.setAttribute( 'data-sizes', sizes );
-	}
+	};
 
 
 })();

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -295,7 +295,7 @@ function tevkori_filter_attachment_image_attributes( $attr, $attachment, $size )
 
 	return $attr;
 }
-add_filter( 'wp_get_attachment_image_attributes', 'tevkori_filter_attachment_image_attributes', 0, 4 );
+add_filter( 'wp_get_attachment_image_attributes', 'tevkori_filter_attachment_image_attributes', 0, 3 );
 
 /**
  * Disable the editor size constraint applied for images in TinyMCE.

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -374,7 +374,6 @@ function tevkori_ajax_srcset() {
 	$srcset = tevkori_get_srcset( $postID, $size );
 
 	// For AJAX requests, we echo the result and then die.
-	echo $srcset;
-	die();
+	wp_send_json( $srcset );
 }
 add_action( 'wp_ajax_tevkori_ajax_srcset', 'tevkori_ajax_srcset' );


### PR DESCRIPTION
* Use the native wp function so that proper header is sent and approriate `die()` function is used.
* Some cleanup to the `wp-tevko-responsive-images.js`
* Corrected accepted args to `wp_get_attachment_image_attributes` filter