### PR TITLE
Tevkori get srcset array test array

### DIFF
--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -156,13 +156,13 @@ function tevkori_get_srcset_array( $id, $size = 'thumbnail' ) {
 	// Get the image meta data.
 	$img_meta = wp_get_attachment_metadata( $id );
 
-	// Build an array with image sizes.
-	$img_sizes = $img_meta['sizes'];
-
 	// Test if there happens to be meta data, bail if none is found
-	if (is_array($image_meta)){
+	if (!is_array($image_meta)){
 		return false;
 	}
+
+	// Build an array with image sizes.
+	$img_sizes = $img_meta['sizes'];
 
 	// Add full size to the img_sizes array.
 	$img_sizes['full'] = array(

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -159,6 +159,11 @@ function tevkori_get_srcset_array( $id, $size = 'thumbnail' ) {
 	// Build an array with image sizes.
 	$img_sizes = $img_meta['sizes'];
 
+	// Test if there happens to be meta data, bail if none is found
+	if (is_array($image_meta)){
+		return false;
+	}
+
 	// Add full size to the img_sizes array.
 	$img_sizes['full'] = array(
 		'width'  => $img_meta['width'],


### PR DESCRIPTION
Adds `is_array` test to `tevkori_get_srcset_array` to make sure that `$image_meta` returns an array. Some images may not have meta information, for example .ico files etc.