### PR TITLE
Don't calculate a srcset when the image data returns no width.

### DIFF
--- a/tests/test-suite.php
+++ b/tests/test-suite.php
@@ -171,6 +171,28 @@ class SampleTest extends WP_UnitTestCase {
 		$this->assertFalse( $sizes );
 	}
 
+	function test_tevkori_get_srcset_array_no_width() {
+		// Filter image_downsize() output.
+		add_filter( 'image_downsize', array( $this, '_test_tevkori_get_srcset_array_no_width_filter' ) );
+
+		// Make our attachement.
+		$id = $this->_test_img();
+		$srcset = tevkori_get_srcset_array( $id, 'medium' );
+
+		// The srcset should be false
+		$this->assertFalse( $srcset );
+
+		// Remove filter.
+		remove_filter( 'image_downsize', array( $this, '_test_tevkori_get_srcset_array_no_width_filter' ) );
+	}
+
+	/**
+	 * Helper funtion to filter image_downsize and return zero values for width and height.
+	 */
+	public function _test_tevkori_get_srcset_array_no_width_filter() {
+		return array( 'http://example.org/foo.jpg', 0, 0, false );
+	}
+
 	function test_tevkori_get_srcset_string() {
 		// make an image
 		$id = $this->_test_img();

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -153,6 +153,11 @@ function tevkori_get_srcset_array( $id, $size = 'thumbnail' ) {
 	// Break image data into url, width, and height.
 	list( $img_url, $img_width, $img_height ) = $img;
 
+	// If we have no width to work with, we should bail (see issue #118).
+	if ( 0 == $img_width ) {
+		return false;
+	}
+
 	// Get the image meta data.
 	$img_meta = wp_get_attachment_metadata( $id );
 


### PR DESCRIPTION
This is a quick fix for #118. I assume the issue is being caused by something filtering the `image_downsize()` function and returning `0` for the width. In those cases we should just bail early rather since we won't be able to calculate aspect ratios for our source candidates for `srcset` anyway.