### PR TITLE
Added check to make sure there's more than one image size.

### DIFF
--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -258,14 +258,6 @@ function tevkori_get_src_sizes( $id, $size = 'thumbnail' ) {
  * @return string HTML for image.
  */
 function tevkori_extend_image_tag( $html, $id, $caption, $title, $align, $url, $size, $alt ) {
-
-	$img_meta = wp_get_attachment_metadata($id);
-
-	// If there are no additional sizes of this image, return the HTML unaltered.
-	if ( empty($img_meta['sizes']) ) {
-		return $html;
-	}
-
 	add_filter( 'editor_max_image_size', 'tevkori_editor_image_size' );
 
 	$sizes = tevkori_get_sizes( $id, $size );
@@ -294,13 +286,6 @@ add_filter( 'image_send_to_editor', 'tevkori_extend_image_tag', 0, 8 );
  */
 function tevkori_filter_attachment_image_attributes( $attr, $attachment, $size ) {
 	$attachment_id = $attachment->ID;
-
-	$img_meta = wp_get_attachment_metadata($attachment_id);
-
-	// If there are no additional sizes of this image, return the HTML unaltered.
-	if ( empty($img_meta['sizes']) ) {
-		return $attr;
-	}
 
 	if ( ! isset( $attr['sizes'] ) ) {
 		$sizes = tevkori_get_sizes( $attachment_id, $size );

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -164,6 +164,11 @@ function tevkori_get_srcset_array( $id, $size = 'thumbnail' ) {
 	// Build an array with image sizes.
 	$img_sizes = $img_meta['sizes'];
 
+	// If the count of image sizes is less than 2, return false.
+	if ( 2 > count($img_sizes) ) {
+		return false;
+	}
+
 	// Add full size to the img_sizes array.
 	$img_sizes['full'] = array(
 		'width'  => $img_meta['width'],
@@ -260,15 +265,20 @@ function tevkori_get_src_sizes( $id, $size = 'thumbnail' ) {
 function tevkori_extend_image_tag( $html, $id, $caption, $title, $align, $url, $size, $alt ) {
 	add_filter( 'editor_max_image_size', 'tevkori_editor_image_size' );
 
+	// Build the srcset attribute.
+	$srcset = tevkori_get_srcset_string( $id, $size );
+
+	// If the srcset is empty, return the HTML unaltered.
+	if ( '' == $srcset ) {
+		return $html;
+	}
+
 	$sizes = tevkori_get_sizes( $id, $size );
 
 	// Build the data-sizes attribute if sizes were returned.
 	if ( $sizes ) {
 		$sizes = 'data-sizes="' . $sizes . '"';
 	}
-
-	// Build the srcset attribute.
-	$srcset = tevkori_get_srcset_string( $id, $size );
 
 	remove_filter( 'editor_max_image_size', 'tevkori_editor_image_size' );
 
@@ -287,6 +297,16 @@ add_filter( 'image_send_to_editor', 'tevkori_extend_image_tag', 0, 8 );
 function tevkori_filter_attachment_image_attributes( $attr, $attachment, $size ) {
 	$attachment_id = $attachment->ID;
 
+	if ( ! isset( $attr['srcset'] ) ) {
+		$srcset = tevkori_get_srcset( $attachment_id, $size );
+
+		if ( '' == $srcset ) {
+			return $attr;
+		}
+
+		$attr['srcset'] = $srcset;
+	}
+
 	if ( ! isset( $attr['sizes'] ) ) {
 		$sizes = tevkori_get_sizes( $attachment_id, $size );
 
@@ -294,11 +314,6 @@ function tevkori_filter_attachment_image_attributes( $attr, $attachment, $size )
 		if ( $sizes ) {
 			$attr['sizes'] = $sizes;
 		}
-	}
-
-	if ( ! isset( $attr['srcset'] ) ) {
-		$srcset = tevkori_get_srcset( $attachment_id, $size );
-		$attr['srcset'] = $srcset;
 	}
 
 	return $attr;

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -260,6 +260,13 @@ function tevkori_get_src_sizes( $id, $size = 'thumbnail' ) {
 function tevkori_extend_image_tag( $html, $id, $caption, $title, $align, $url, $size, $alt ) {
 	add_filter( 'editor_max_image_size', 'tevkori_editor_image_size' );
 
+	$img_meta = wp_get_attachment_metadata($id);
+
+	// If there are no additional sizes of this image, return the HTML unaltered.
+	if ( empty($img_meta['sizes']) ) {
+		return $html;
+	}
+
 	$sizes = tevkori_get_sizes( $id, $size );
 
 	// Build the data-sizes attribute if sizes were returned.
@@ -286,6 +293,13 @@ add_filter( 'image_send_to_editor', 'tevkori_extend_image_tag', 0, 8 );
  */
 function tevkori_filter_attachment_image_attributes( $attr, $attachment, $size ) {
 	$attachment_id = $attachment->ID;
+
+	$img_meta = wp_get_attachment_metadata($attachment_id);
+
+	// If there are no additional sizes of this image, return the HTML unaltered.
+	if ( empty($img_meta['sizes']) ) {
+		return $attr;
+	}
 
 	if ( ! isset( $attr['sizes'] ) ) {
 		$sizes = tevkori_get_sizes( $attachment_id, $size );

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -164,11 +164,6 @@ function tevkori_get_srcset_array( $id, $size = 'thumbnail' ) {
 	// Build an array with image sizes.
 	$img_sizes = $img_meta['sizes'];
 
-	// If the count of image sizes is less than 2, return false.
-	if ( 2 > count($img_sizes) ) {
-		return false;
-	}
-
 	// Add full size to the img_sizes array.
 	$img_sizes['full'] = array(
 		'width'  => $img_meta['width'],
@@ -197,8 +192,9 @@ function tevkori_get_srcset_array( $id, $size = 'thumbnail' ) {
 		}
 	}
 
-	if ( empty( $arr ) ) {
-		return false;
+	// If there is only one size, return false.
+	if ( 2 > count( $arr ) ) {
+	    return false;
 	}
 
 	return $arr;

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -168,7 +168,7 @@ function tevkori_get_srcset_array( $id, $size = 'thumbnail' ) {
 	$img_sizes['full'] = array(
 		'width'  => $img_meta['width'],
 		'height' => $img_meta['height'],
-		'file'   => $img_meta['file'] 
+		'file'   => $img_meta['file']
 	);
 	if ( strrpos( $img_meta['file'], '/' ) !== false ) {
 		$img_sizes['full']['file'] = substr( $img_meta['file'], strrpos( $img_meta['file'], '/' ) + 1 );
@@ -258,7 +258,6 @@ function tevkori_get_src_sizes( $id, $size = 'thumbnail' ) {
  * @return string HTML for image.
  */
 function tevkori_extend_image_tag( $html, $id, $caption, $title, $align, $url, $size, $alt ) {
-	add_filter( 'editor_max_image_size', 'tevkori_editor_image_size' );
 
 	$img_meta = wp_get_attachment_metadata($id);
 
@@ -266,6 +265,8 @@ function tevkori_extend_image_tag( $html, $id, $caption, $title, $align, $url, $
 	if ( empty($img_meta['sizes']) ) {
 		return $html;
 	}
+
+	add_filter( 'editor_max_image_size', 'tevkori_editor_image_size' );
 
 	$sizes = tevkori_get_sizes( $id, $size );
 


### PR DESCRIPTION
Fix for issue #121: So I checked for more than one image size by checking the sizes array of the WordPress image metadata array. If it's empty, then `tevkori_extend_image_tag` and `tevkori_filter_attachment_image_attributes` return `$html` and `$attr`, respectively.

I tested this on a fresh VVV install with a 100x100 image and a 500x500 image and got the expected results.

For better efficiency, we could pass through the `$img_meta` array to `tevkori_get_srcset_array`, which both of those functions already use. It would be a small duplication of code, but not necessarily a duplication of effort, since both filters will never be running at the same time.