### PR TITLE
Add a filter for sizes.

### DIFF
--- a/tests/test-suite.php
+++ b/tests/test-suite.php
@@ -115,6 +115,28 @@ class SampleTest extends WP_UnitTestCase {
 		$this->assertSame($expected, $sizes);
 	}
 
+	function test_filter_tevkori_get_sizes_string() {
+		// Add our test filter.
+		add_filter( 'tevkori_image_sizes_args', array( $this, '_test_tevkori_image_sizes_args' ) );
+
+		// Set up our test.
+		$id = $this->_test_img();
+		$sizes = tevkori_get_sizes($id, 'medium');
+
+		// Evaluate that the sizes returned is what we expected.
+		$this->assertSame( $sizes, '100vm');
+
+		remove_filter( 'tevkori_image_sizes_args', array( $this, '_test_tevkori_image_sizes_args' ) );
+	}
+
+	/**
+	 * A simple test filter for tevkori_get_sizes().
+	 */
+	function _test_tevkori_image_sizes_args( $args ) {
+		$args['sizes'] = "100vm";
+		return $args;
+	}
+
 	function test_tevkori_get_sizes_string() {
 		// make an image
 		$id = $this->_test_img();

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -69,6 +69,17 @@ function tevkori_get_sizes( $id, $size = 'thumbnail', $args = null ) {
 
 	$args = wp_parse_args( $args, $defaults );
 
+	/**
+	* Filter arguments used to create sizes attribute.
+	*
+	* @since 2.4.0
+	*
+	* @param array   $args  An array of arguments used to create a sizes attribute.
+	* @param int     $id    Post ID of the original image.
+	* @param string  $size  Name of the image size being used.
+	*/
+	$args = apply_filters( 'tevkori_image_sizes_args', $args, $id, $size );
+
 	// If sizes is passed as a string, just use the string.
 	if ( is_string( $args['sizes'] ) ) {
 		$size_list = $args['sizes'];


### PR DESCRIPTION
Add filter hook `tevkori_image_sizes_args` and includes basic unit tests (addresses #101).

First stab at adding a filter to `tevkori_get_sizes()` so developers can more easily override the default `sizes` attribute. This implementation filters the `$args` variable inside `tevkori_get_sizes()` before the function creates the sizes list, but after the default arguments have been applied.

The filter hook passes three arguments:

* **$args**   *(array)* The `$args` array to be filtered and returned.
* **$id**       *(int)* The post ID of the image.
* **$size**    *(string)* The name of the image crop size being affected.

Functions that hook into this filter should return an array in the form of the `$args` array for `tevkori_get_sizes()`.

**Ex: Changing the default sizes array based on the crop size.**
```
add_filter( 'tevkori_image_sizes_args', 'my_custom_sizes' );

function my_custom_sizes( $args, $id, $size ) {
    if ( $size == 'medium' ) {
        $args['sizes'] = '(max-width: 400px) 100vw, (max-width: 800px) 50vw, (max-width: 1200px) 33vw';
    }

    return $args;
}
```

Take it for a spin and let me know what you think.