### PR TITLE
Compare aspect ratio in relative values, not absolute values

### DIFF
--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -199,7 +199,8 @@ function tevkori_get_srcset_array( $id, $size = 'thumbnail' ) {
 		// Calculate the new image ratio
 		$img_ratio_compare = $img['height'] / $img['width'];
 
-		if ( abs($img_ratio - $img_ratio_compare) < 0.01 ) {
+		// If the new ratio differs by less than 0.01, use it.
+		if ( abs( $img_ratio - $img_ratio_compare ) < 0.01 ) {
 			$arr[] = $img_base_url . $img['file'] . ' ' . $img['width'] .'w';
 		}
 	}

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -196,11 +196,10 @@ function tevkori_get_srcset_array( $id, $size = 'thumbnail' ) {
 	// Only use sizes with same aspect ratio.
 	foreach ( $img_sizes as $img_size => $img ) {
 
-		// Calculate the height we would expect if the image size has the same aspect ratio.
-		$expected_height = (int) round( $img['width'] * $img_ratio );
+		// Calculate the new image ratio
+		$img_ratio_compare = $img['height'] / $img['width'];
 
-		// If image height doesn't varies more than 2px over the expected, use it.
-		if ( $img['height'] >= $expected_height - 2 && $img['height'] <= $expected_height + 2  ) {
+		if ( abs($img_ratio - $img_ratio_compare) < 0.01 ) {
 			$arr[] = $img_base_url . $img['file'] . ' ' . $img['width'] .'w';
 		}
 	}


### PR DESCRIPTION
The ratio comparison currently misses out on some sizes. This is because the original size comes from the thumbnail, real-world example:

Original size: 188x480
Size full: 1563x4000 (Expected height: 1567 - difference is 4)

The ratio differences with my images is around 0.001, so 0.01 should be enough.