### PR TITLE
Edit WP releases in Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ php:
 env:
     - WP_VERSION=latest WP_MULTISITE=0
     - WP_VERSION=latest WP_MULTISITE=1
+    - WP_VERSION=4.2 WP_MULTISITE=0
+    - WP_VERSION=4.2 WP_MULTISITE=1
+    - WP_VERSION=4.1 WP_MULTISITE=0
+    - WP_VERSION=4.1 WP_MULTISITE=1
     - WP_VERSION=4.0 WP_MULTISITE=0
     - WP_VERSION=4.0 WP_MULTISITE=1
     - WP_VERSION=3.9 WP_MULTISITE=0
@@ -22,5 +26,5 @@ script: phpunit
 
 notifications:
   email: false
-  
+
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,5 @@ script: phpunit
 
 notifications:
   email: false
+  
+sudo: false

--- a/readme.md
+++ b/readme.md
@@ -135,9 +135,26 @@ The only external dependency included in this plugin is [Picturefill](http://sco
 We use a hook because if you attempt to dequeue a script before it's enqueued, wp_dequeue_script has no effect. (If it's still being loaded, you may need to specify a [priority](http://codex.wordpress.org/Function_Reference/add_action).)
 
 ## Version
-2.3.1
+2.4.0
 
 ## Changelog
+
+- Added filter for tevkori_get_sizes, with tests
+- Added Composer support
+- Compare aspect ratio in relative values, not absolute values
+- Cleanup of code style and comments added
+- Added PHP 5.2 to our Travis test matrix
+- Fixed unit test loading
+- Preventing duplicates in srcset array
+- Updated docs for advanced image compression
+- Formatting cleanup in readme.md
+- Bump plugin 'Tested up to:' value to 4.3
+- Remove extra line from readme.txt
+- Added changelog items from 2.3.1 to the readme.txt file
+- Added 'sudo: false' to travis.ci to use new TravisCI infrastructure
+- Removing the srcset and sizes attributes if there is only one source present for the image
+
+**2.3.1**
 
 - First char no longer stripped from file name if there's no slash
 - Adding test for when uploads directory not organized by date

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://app.etapestry.com/hosted/BoweryResidentsCommittee/OnlineDon
 Tags: Responsive, Images, Responsive Images, SRCSET, Picturefill
 Requires at least: 4.1
 Tested up to: 4.3
-Stable tag: 2.3.0
+Stable tag: 2.4.0
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === RICG Responsive Images ===
-Contributors: tevko, wilto, joemcgill, jaspermdegroot,chriscoyier, Michael McGinnis, ryelle, drrobotnik, nacin , georgestephanis, helen, wordpressdotorg, Bocoup
+Contributors: tevko, wilto, joemcgill, jaspermdegroot, chriscoyier, Michael McGinnis, ryelle, drrobotnik, nacin , georgestephanis, helen, wordpressdotorg, Bocoup
 Donate link: https://app.etapestry.com/hosted/BoweryResidentsCommittee/OnlineDonation.html
 Tags: Responsive, Images, Responsive Images, SRCSET, Picturefill
 Requires at least: 4.1

--- a/readme.txt
+++ b/readme.txt
@@ -26,13 +26,29 @@ This plugin works by including all available image sizes for each image upload. 
 
 == Changelog ==
 
-= 2.3.1
+= 2.4.0 =
+- Added filter for tevkori_get_sizes, with tests
+- Added Composer support
+- Compare aspect ratio in relative values, not absolute values
+- Cleanup of code style and comments added
+- Added PHP 5.2 to our Travis test matrix
+- Fixed unit test loading
+- Preventing duplicates in srcset array
+- Updated docs for advanced image compression 
+- Formatting cleanup in readme.md
+- Bump plugin 'Tested up to:' value to 4.3
+- Remove extra line from readme.txt
+- Added changelog items from 2.3.1 to the readme.txt file
+- Added 'sudo: false' to travis.ci to use new TravisCI infrastructure
+- Removing the srcset and sizes attributes if there is only one source present for the image
+
+= 2.3.1 = 
 - First char no longer stripped from file name if there's no slash
 - Adding test for when uploads directory not organized by date
 - Don't calculate a srcset when the image data returns no width
 - Add test for image_downsize returning 0 as a width
 
-= 2.3.0
+= 2.3.0 =
 * Improved performance of get_srcset_array
 * Added advanced image compression option (available by adding hook to functions.php)
 * Duplicate entires now filtered out from srcset array

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === RICG Responsive Images ===
-Contributors: tevko, wilto, chriscoyier, joemcgill, Michael McGinnis, ryelle, drrobotnik, nacin , georgestephanis, helen, wordpressdotorg, Bocoup
+Contributors: tevko, wilto, joemcgill, jaspermdegroot,chriscoyier, Michael McGinnis, ryelle, drrobotnik, nacin , georgestephanis, helen, wordpressdotorg, Bocoup
 Donate link: https://app.etapestry.com/hosted/BoweryResidentsCommittee/OnlineDonation.html
 Tags: Responsive, Images, Responsive Images, SRCSET, Picturefill
 Requires at least: 4.1

--- a/tests/test-suite.php
+++ b/tests/test-suite.php
@@ -195,20 +195,14 @@ class SampleTest extends WP_UnitTestCase {
 		update_option( 'uploads_use_yearmonth_folders', $uploads_use_yearmonth_folders );
 	}
 
-	function test_tevkori_get_srcset_array_thumb() {
+	function test_tevkori_get_srcset_array_single_srcset() {
 		// make an image
 		$id = $this->_test_img();
 		$sizes = tevkori_get_srcset_array( $id, 'thumbnail' );
 
 		$image = wp_get_attachment_metadata( $id );
 
-		$year_month = date('Y/m');
-		$expected = array(
-			$image['sizes']['thumbnail']['width'] => 'http://example.org/wp-content/uploads/' . $year_month = date('Y/m') . '/'
-				. $image['sizes']['thumbnail']['file'] . ' ' . $image['sizes']['thumbnail']['width'] . 'w',
-		);
-
-		$this->assertSame( $expected, $sizes );
+		$this->assertFalse( $sizes );
 	}
 
 	function test_tevkori_get_srcset_array_false() {		// make an image

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -221,7 +221,7 @@ function tevkori_get_srcset_array( $id, $size = 'thumbnail' ) {
 		}
 	}
 
-	if ( empty( $arr ) ) {
+	if ( count( $arr ) <== 1 ) {
 		return false;
 	}
 

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -221,7 +221,7 @@ function tevkori_get_srcset_array( $id, $size = 'thumbnail' ) {
 		}
 	}
 
-	if ( count( $arr ) <== 1 ) {
+	if ( count( $arr ) <= 1 ) {
 		return false;
 	}
 


### PR DESCRIPTION
Updated the Travis environment list to include WordPress 4.1 and 4.2.