### PR TITLE
Add PHP7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
     - 5.4
     - 5.5
     - 5.6
+    - 7.0
 
 env:
     - WP_VERSION=latest WP_MULTISITE=0
@@ -16,6 +17,11 @@ env:
     - WP_VERSION=4.1 WP_MULTISITE=1
     - WP_VERSION=4.0 WP_MULTISITE=0
     - WP_VERSION=4.0 WP_MULTISITE=1
+
+allow_failures:
+  - php: 7.0
+
+fast_finish: true
 
 before_script:
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION


### PR DESCRIPTION
WordPress is testing against PHP7 in preparation for its upcoming release so we should as well. Following WP's lead, we can allow these tests to fail and still pass the build.