### PR TITLE
Return single source candidates in `tevkori_get_srcset_array()`

### DIFF
--- a/tests/test-suite.php
+++ b/tests/test-suite.php
@@ -223,14 +223,15 @@ class SampleTest extends WP_UnitTestCase {
 		update_option( 'uploads_use_yearmonth_folders', $uploads_use_yearmonth_folders );
 	}
 
-	function test_tevkori_get_srcset_array_single_srcset() {
+	function test_tevkori_get_srcset_single_srcset() {
 		// make an image
 		$id = $this->_test_img();
 		// In our tests, thumbnails would only return a single srcset candidate,
 		// in which case we don't bother returning a srcset array.
-		$sizes = tevkori_get_srcset_array( $id, 'thumbnail' );
+		$sizes = tevkori_get_srcset( $id, 'thumbnail' );
 
-		$this->assertFalse( $sizes );
+		$this->assertTrue( 1 === count( tevkori_get_srcset_array( $id, 'thumbnail' ) ) );
+		$this->assertFalse( tevkori_get_srcset( $id, 'thumbnail' ) );
 	}
 
 	/**

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -232,10 +232,6 @@ function tevkori_get_srcset_array( $id, $size = 'thumbnail' ) {
 		}
 	}
 
-	if ( count( $arr ) <= 1 ) {
-		return false;
-	}
-
 	/**
 	 * Filter the output of tevkori_get_srcset_array().
 	 *
@@ -260,7 +256,7 @@ function tevkori_get_srcset_array( $id, $size = 'thumbnail' ) {
 function tevkori_get_srcset( $id, $size = 'thumbnail' ) {
 	$srcset_array = tevkori_get_srcset_array( $id, $size );
 
-	if ( empty( $srcset_array ) ) {
+	if ( count( $srcset_array ) <= 1 ) {
 		return false;
 	}
 


### PR DESCRIPTION
We should consider returning an array in `tevkori_get_srcset_array()` when there is only a single source candidate and move the logic requiring multiple source candidates to `tevkori_get_srcset()` so we wouldn't add `srcset` value when it only contains a single source.