### PR TITLE
Feature detect need for picturefill

### DIFF
--- a/js/srcset-feature-check.js
+++ b/js/srcset-feature-check.js
@@ -1,26 +1,13 @@
-(function( window ){
-	var document = window.document;
-	var config = window._wpResponsiveImagesSettings;
-	var image  = new window.Image();
-
-	function browserSupportsResponsiveImages() {
-		// Adapted from picturefill 2.3.1
-		if ( 'sizes' in image && 'currentSrc' in image && 'srcset' in image ) {
-			return true;
-		}
-
-		return false;
+(function( document, config, image, script, firstScript ){
+	// Adapted from picturefill 2.3.1
+	if ( 'sizes' in image && 'currentSrc' in image && 'srcset' in image ) {
+		return;
 	}
 
-	function enqueueScript( src ) {
-		var script = document.createElement( 'script' );
-		var firstScript = document.getElementsByTagName( 'script' )[0];
+	script = document.createElement( 'script' );
+	firstScript = document.getElementsByTagName( 'script' )[0];
 
-		script.async = script.src = src;
-		firstScript.parentNode.insertBefore( script, firstScript );
-	}
+	script.async = script.src = config.picturefillSource;
+	firstScript.parentNode.insertBefore( script, firstScript );
 
-	if ( false === browserSupportsResponsiveImages() ) {
-		enqueueScript( config.picturefillSource );
-	}
-})( window );
+})( document, _wpResponsiveImagesSettings, new Image() );

--- a/js/srcset-feature-check.js
+++ b/js/srcset-feature-check.js
@@ -1,0 +1,26 @@
+(function( window ){
+	var document = window.document;
+	var config = window._wpResponsiveImagesSettings;
+	var image  = new window.Image();
+
+	function browserSupportsResponsiveImages() {
+		// Adapted from picturefill 2.3.1
+		if ( 'sizes' in image && 'currentSrc' in image && 'srcset' in image ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	function enqueueScript( src ) {
+		var script = document.createElement( 'script' );
+		var firstScript = document.getElementsByTagName( 'script' )[0];
+
+		script.async = script.src = src;
+		firstScript.parentNode.insertBefore( script, firstScript );
+	}
+
+	if ( false === browserSupportsResponsiveImages() ) {
+		enqueueScript( config.picturefillSource );
+	}
+})( window );

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -44,7 +44,27 @@ if ( class_exists( 'Imagick' ) ) {
  * Enqueue bundled version of the Picturefill library.
  */
 function tevkori_get_picturefill() {
-	wp_enqueue_script( 'picturefill', plugins_url( 'js/picturefill.min.js', __FILE__ ), array(), '2.3.1', true );
+	$picturefill_version = '2.3.1';
+	$picturefill_source = plugins_url( 'js/picturefill.min.js', __FILE__ );
+	$picturefill_source = add_query_arg( array(
+		'ver' => $picturefill_version,
+	), $picturefill_source );
+
+	/** This filter is documented in wp-includes/class.wp-scripts.php */
+	$picturefill_source = apply_filters( 'script_loader_src', $picturefill_source, 'picturefill' );
+
+	$settings = array(
+		'picturefillSource' => $picturefill_source,
+	);
+
+	$feature_check_source = plugin_dir_path( __FILE__ ) . 'js/srcset-feature-check.js';
+
+	?>
+	<script type='text/javascript'>
+		window._wpResponsiveImagesSettings = <?php echo wp_json_encode( $settings ); ?>;
+		<?php readfile( $feature_check_source ); ?>
+	</script>
+	<?php
 }
 add_action( 'wp_enqueue_scripts', 'tevkori_get_picturefill' );
 

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -66,7 +66,7 @@ function tevkori_get_picturefill() {
 	</script>
 	<?php
 }
-add_action( 'wp_enqueue_scripts', 'tevkori_get_picturefill' );
+add_action( 'wp_head', 'tevkori_get_picturefill' );
 
 /**
  * Return a source size attribute for an image from an array of values.


### PR DESCRIPTION
See gh-186

Feature detects the need for picturefill and loads asynchronously if needed. This operates in the same fashion as the Emoji pollyfill in core.

The feature detection is output directly in the HTML header, in the first push I have inserted the uncompressed code using a readfile command. In the patch for merge I'd suggest using grunt to insert the compressed code directly in the PHP file.

All this is very similar to the emoji-loader script, it could be worth repurposing the emoji-loader to a pollyfill loader.

It's worth reminding you all outputting the Emoji feature detection in the HTML header was controversial. The performance gains were not well understood at the time.