### PR TITLE
Filter cache warming

### DIFF
--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -309,6 +309,15 @@ function tevkori_filter_content_images( $content ) {
 	}
 
 	if ( 0 < count( $ids ) ) {
+		/**
+		 * Warm object caches for use with wp_get_attachment_metadata.
+		 *
+		 * To avoid making a database call for each image, WP_Query is called
+		 * as a single query with the IDs of all images in the post. This warms
+		 * the object cache with the meta information for all images.
+		 *
+		 * This loop is not used directly.
+		 **/
 		$attachments = new WP_Query(array(
 			'post_type'  => 'attachment',
 			'posts_per_page' => '-1',

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -294,6 +294,29 @@ function tevkori_filter_content_images( $content ) {
 	$uploads_dir = wp_upload_dir();
 	$path_to_upload_dir = $uploads_dir['baseurl'];
 
+	preg_match_all( '|<img ([^>]+' . $path_to_upload_dir . '[^>]+)[\s?][\/?]>|i', $content, $matches );
+
+	$images = $matches[0];
+	$ids = array();
+
+	foreach( $images as $image ) {
+		if ( preg_match( '/wp-image-([0-9]+)/i', $image, $class_id ) ) {
+			(int) $id = $class_id[1];
+			if( $id ) {
+				$ids[] = $id;
+			}
+		}
+	}
+
+	if ( 0 < count( $ids ) ) {
+		$attachments = new WP_Query(array(
+			'post_type'  => 'attachment',
+			'posts_per_page' => '-1',
+			'post_status' => 'inherit',
+			'post__in' => $ids,
+		));
+	}
+
 	$content = preg_replace_callback(
 		'|<img ([^>]+' . $path_to_upload_dir . '[^>]+)[\s?][\/?]>|i',
 		'_tevkori_filter_content_images_callback',


### PR DESCRIPTION
This warms the WordPress object cache for `wp_get_attachment_metadata` calls using a `WP_Query` call.

* Collects image IDs in an array
* Queries attachments using IDs of said attachments
* cache is warm, the following calls to `wp_get_attachment_metadata` will not trigger a DB call