### PR TITLE
Streamlining code

### DIFF
--- a/tests/test-suite.php
+++ b/tests/test-suite.php
@@ -198,6 +198,25 @@ class SampleTest extends WP_UnitTestCase {
 		$this->assertSame( $expected, $sizes );
 	}
 
+	function test_tevkori_get_srcset_array_random_size_name() {
+		// make an image
+		$id = $this->_test_img();
+		$sizes = tevkori_get_srcset_array( $id, 'foo' );
+
+		$year_month = date('Y/m');
+		$image = wp_get_attachment_metadata( $id );
+
+		$expected = array(
+			$image['sizes']['medium']['width'] => 'http://example.org/wp-content/uploads/' . $year_month = date('Y/m') . '/'
+				. $image['sizes']['medium']['file'] . ' ' . $image['sizes']['medium']['width'] . 'w',
+			$image['sizes']['large']['width'] => 'http://example.org/wp-content/uploads/' . $year_month = date('Y/m') . '/'
+				. $image['sizes']['large']['file'] . ' ' . $image['sizes']['large']['width'] . 'w',
+			$image['width'] => 'http://example.org/wp-content/uploads/' . $image['file'] . ' ' . $image['width'] .'w'
+		);
+
+		$this->assertSame( $expected, $sizes );
+	}
+
 	function test_tevkori_get_srcset_array_no_date_upoads() {
 		// Save the current setting for uploads folders
 		$uploads_use_yearmonth_folders = get_option( 'uploads_use_yearmonth_folders' );
@@ -280,7 +299,7 @@ class SampleTest extends WP_UnitTestCase {
 
 	function test_tevkori_get_srcset_array_no_width() {
 		// Filter image_downsize() output.
-		add_filter( 'image_downsize', array( $this, '_test_tevkori_get_srcset_array_no_width_filter' ) );
+		add_filter( 'wp_generate_attachment_metadata', array( $this, '_test_tevkori_get_srcset_array_no_width_filter' ) );
 
 		// Make our attachement.
 		$id = $this->_test_img();
@@ -290,14 +309,16 @@ class SampleTest extends WP_UnitTestCase {
 		$this->assertFalse( $srcset );
 
 		// Remove filter.
-		remove_filter( 'image_downsize', array( $this, '_test_tevkori_get_srcset_array_no_width_filter' ) );
+		remove_filter( 'wp_generate_attachment_metadata', array( $this, '_test_tevkori_get_srcset_array_no_width_filter' ) );
 	}
 
 	/**
 	 * Helper funtion to filter image_downsize and return zero values for width and height.
 	 */
-	public function _test_tevkori_get_srcset_array_no_width_filter() {
-		return array( 'http://example.org/foo.jpg', 0, 0, false );
+	public function _test_tevkori_get_srcset_array_no_width_filter( $meta ) {
+		$meta['sizes']['medium']['width'] = 0;
+		$meta['sizes']['medium']['height'] = 0;
+		return $meta;
 	}
 
 	function test_tevkori_get_srcset_string() {

--- a/wp-tevko-responsive-images.php
+++ b/wp-tevko-responsive-images.php
@@ -301,7 +301,9 @@ function tevkori_filter_content_images( $content ) {
 	$uploads_dir = wp_upload_dir();
 	$path_to_upload_dir = $uploads_dir['baseurl'];
 
-	preg_match_all( '|<img ([^>]+' . $path_to_upload_dir . '[^>]+)[\s?][\/?]>|i', $content, $matches );
+	// Pattern for matching all images with a `src` from the uploads directory.
+	$pattern = '|<img ([^>]+' . preg_quote( $path_to_upload_dir ) . '[^>]+)>|i';
+	preg_match_all( $pattern, $content, $matches );
 
 	$images = $matches[0];
 	$ids = array();
@@ -334,7 +336,7 @@ function tevkori_filter_content_images( $content ) {
 	}
 
 	$content = preg_replace_callback(
-		'|<img ([^>]+' . $path_to_upload_dir . '[^>]+)[\s?][\/?]>|i',
+		$pattern,
 		'_tevkori_filter_content_images_callback',
 		$content
 	);
@@ -426,6 +428,10 @@ function _tevkori_filter_content_images_callback( $image ) {
 		);
 
 		$sizes = tevkori_get_sizes_string( $id, $size, $args );
+
+		// Strip trailing slashes and whitespaces from the `$atts` string.
+		$atts = trim( rtrim( $atts, '/' ) );
+
 		$image_html = "<img " . $atts . " " . $srcset . " " . $sizes . " />";
 	};
 


### PR DESCRIPTION
These changes address some of the issues brought up by @azaozz in #187.

* In 5b99b4b we can avoid a call to `image_downsize()` in when creating `sizes` attributes by passing the image height and width directly to `tevkori_get_sizes()` through the `$atts` parameter.
* In a96d0fc I cleaned up the regex in the display filter and added a `preg_quote()` wrapper around `$path_to_upload_dir`. Feels like we should be able to eliminate one of the `preg_match` runs in the display filter but this is at least an improvement for now.
