### PR TITLE
Streamlining of 226 backcompat PR

### DIFF
--- a/tests/test-suite.php
+++ b/tests/test-suite.php
@@ -72,6 +72,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 
 	/**
 	 * @expectedDeprecated tevkori_get_sizes
+	 * @group 226
 	 */
 	function test_tevkori_get_sizes_with_args() {
 		// Make an image.
@@ -90,12 +91,12 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 					'mq_name'    => 'min-width'
 				),
 				array(
-					'size_value' => 'calc(100vm - 30px)'
+					'size_value' => 'calc(100vw - 30px)'
 				),
 			)
 		);
 
-		$expected = '(min-width: 60em) 10em, (min-width: 30em) 20em, calc(100vm - 30px)';
+		$expected = '(min-width: 60em) 10em, (min-width: 30em) 20em, calc(100vw - 30px)';
 		$sizes = tevkori_get_sizes( $id, 'medium', $args );
 
 		$this->assertSame( $expected, $sizes );
@@ -103,8 +104,9 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 
 	/**
 	 * @expectedDeprecated tevkori_get_sizes
+	 * @group 226
 	 */
-	function test_filter_tevkori_get_sizes_string() {
+	function test_filter_tevkori_get_sizes() {
 		// Add our test filter.
 		add_filter( 'tevkori_image_sizes_args', array( $this, '_test_tevkori_image_sizes_args' ) );
 
@@ -113,7 +115,24 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 		$sizes = tevkori_get_sizes($id, 'medium');
 
 		// Evaluate that the sizes returned is what we expected.
-		$this->assertSame( $sizes, '100vm' );
+		$this->assertSame( $sizes, '100vw' );
+
+		remove_filter( 'tevkori_image_sizes_args', array( $this, '_test_tevkori_image_sizes_args' ) );
+	}
+
+	/**
+	 * @group 226
+	 */
+	function test_filter_shim_calculate_image_sizes() {
+		// Add our test filter.
+		add_filter( 'tevkori_image_sizes_args', array( $this, '_test_tevkori_image_sizes_args' ) );
+
+		// A size array is the min required data for `wp_calculate_image_sizes()`.
+		$size = array( 300, 150 );
+		$sizes = wp_calculate_image_sizes( $size, null, null );
+
+		// Evaluate that the sizes returned is what we expected.
+		$this->assertSame( $sizes, '100vw' );
 
 		remove_filter( 'tevkori_image_sizes_args', array( $this, '_test_tevkori_image_sizes_args' ) );
 	}
@@ -122,7 +141,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 	 * A simple test filter for tevkori_get_sizes().
 	 */
 	function _test_tevkori_image_sizes_args( $args ) {
-		$args['sizes'] = "100vm";
+		$args['sizes'] = "100vw";
 		return $args;
 	}
 

--- a/wp-tevko-deprecated-functions.php
+++ b/wp-tevko-deprecated-functions.php
@@ -124,14 +124,50 @@ $tevkori_image_sizes_args_param = null;
 function tevkori_get_sizes( $id, $size = 'medium', $args = null ) {
 	_deprecated_function( __FUNCTION__, '3.0.0', 'wp_get_attachment_image_sizes()' );
 
+	/*
+	 * If this function is passed with an $args parameter, we need to parse the
+	 * $args parameter as we were doing previously, and then save it to a static
+	 * variable using `_tevkori_sizes_has_args()` which can be accessed from the
+	 * `_tevkori_image_sizes_args_shim()` filter in `wp_calculate_image_sizes()`
+	 */
 	if ( $args ) {
-		global $tevkori_image_sizes_args_param;
+		// Try to get the image width from `$args` before calling `image_downsize()`.
+		if ( is_array( $args ) && ! empty( $args['width'] ) ) {
+			$img_width = (int) $args['width'];
+		} else {
+			$img_width = ( $img = image_downsize( $id, $size ) ) ? $img[1] : false;
+		}
 
-		$tevkori_image_sizes_args_param = $args;
+		// Bail early if '$image_width' isn't set.
+		if ( ! $img_width ) {
+			return false;
+		}
+
+		// Set the image width in pixels.
+		$img_width = $img_width . 'px';
+		// Set up our default values.
+		$defaults = array(
+			'sizes' => array(
+				array(
+					'size_value' => '100vw',
+					'mq_value'   => $img_width,
+					'mq_name'    => 'max-width'
+				),
+				array(
+					'size_value' => $img_width
+				),
+			)
+		);
+
+		$args = wp_parse_args( $args, $defaults );
+
+		// Set our static sizes args.
+		_tevkori_sizes_has_args( $args );
 
 		$sizes = wp_get_attachment_image_sizes( $id, $size );
 
-		$tevkori_image_sizes_args_param = null;
+		// Unset our static sizes args.
+		_tevkori_sizes_has_args( false );
 
 		return $sizes;
 	} else {
@@ -150,105 +186,110 @@ function tevkori_get_sizes( $id, $size = 'medium', $args = null ) {
  * @return string A source size value for use in a 'sizes' attribute.
  */
 function _tevkori_image_sizes_args_shim( $sizes, $size, $image_src, $image_meta, $id ) {
-	global $tevkori_image_sizes_args_param;
+	// Check for args that were passed to `tevkori_get_sizes()`;
+	$args = _tevkori_sizes_has_args();
 
-	if ( has_filter( 'tevkori_image_sizes_args' ) || $tevkori_image_sizes_args_param ) {
-		// Transform the 'sizes' value string into an array.
-		if ( ! is_string( $sizes ) ) {
-			return $sizes;
-		}
-
-		// Split up the 'sizes' string.
-		$values = explode( ', ', $sizes );
-
-		// Set up the default array.
-		$defaults = array(
-			'sizes' => array()
-		);
-
-		foreach ( $values as $value ) {
-			// Check if it contains a media query.
-			if ( strpos( $value, ') ' ) ) {
-				$arr = array();
-
-				// Split media query and size value.
-				$parts = explode( ') ', $value );
-
-				// Split media query name and value.
-				$mq_parts = explode( ': ', $parts[0] );
-
-				$arr['size_value'] = $parts[1];
-				$arr['mq_value']   = $mq_parts[1];
-				$arr['mq_name']    = ltrim( $mq_parts[0], '(' );
-
-				$defaults['sizes'][] = $arr;
-
-			// Else it is a single width value.
-			} else {
-				$arr = array();
-				$arr['size_value'] = $value;
-				$defaults['sizes'][] = $arr;
-			}
-		}
-
-		if ( $tevkori_image_sizes_args_param ) {
-			$args = wp_parse_args( $tevkori_image_sizes_args_param, $defaults );
-		} else {
-			$args = $defaults;
-		}
-
-		/**
-		* Filter arguments used to create the 'sizes' attribute value.
-		*
-		* @since 2.4.0
-		* @deprecated 3.0.0 Use 'wp_calculate_image_srcset'
-		* @see 'wp_calculate_image_srcset'
-		*
-		* @param array        $args An array of arguments used to create a 'sizes' attribute.
-		* @param int          $id   Post ID of the original image.
-		* @param array|string $size Image size. Image size or an array of width and height
-		*                           values in pixels (in that order).
-		*/
-		$args = apply_filters( 'tevkori_image_sizes_args', $args, $id, $size );
-
-		// If sizes is passed as a string, just use the string.
-		if ( is_string( $args['sizes'] ) ) {
-			$size_list = $args['sizes'];
-
-		// Otherwise, breakdown the array and build a sizes string.
-		} elseif ( is_array( $args['sizes'] ) ) {
-			$size_list = '';
-
-			foreach ( $args['sizes'] as $size ) {
-				// Use 100vw as the size value unless something else is specified.
-				$size_value = ( $size['size_value'] ) ? $size['size_value'] : '100vw';
-
-				// If a media length is specified, build the media query.
-				if ( ! empty( $size['mq_value'] ) ) {
-					$media_length = $size['mq_value'];
-
-					// Use max-width as the media condition unless min-width is specified.
-					$media_condition = ( ! empty( $size['mq_name'] ) ) ? $size['mq_name'] : 'max-width';
-
-					// If a media length was set, create the media query.
-					$media_query = '(' . $media_condition . ": " . $media_length . ') ';
-				} else {
-					// If no media length was set, '$media_query' is blank.
-					$media_query = '';
-				}
-				// Add to the source size list string.
-				$size_list .= $media_query . $size_value . ', ';
-			}
-			// Remove the trailing comma and space from the end of the string.
-			$size_list = substr( $size_list, 0, -2 );
-		}
-		// If '$size_list' is defined return the string, otherwise return '$sizes'.
-		return ( $size_list ) ? $size_list : $sizes;
-	} else {
+	// Bail early if no $args were passed or the old filter wasn't used.
+	if ( ! ( $args || has_filter( 'tevkori_image_sizes_args') ) ) {
 		return $sizes;
 	}
+
+	// If no $args are present, we'll build the default args.
+	if ( ! $args ) {
+		// recreate default args
+		if ( is_array( $size ) ) {
+			$img_width = (int) $size[0];
+		} else {
+			$img = image_downsize( $id, $size );
+			$img_width = $img[1];
+		}
+
+		$args = array(
+			'sizes' => array(
+				array(
+					'size_value' => '100vw',
+					'mq_value'   => $img_width,
+					'mq_name'    => 'max-width'
+				),
+				array(
+					'size_value' => $img_width
+				),
+			)
+		);
+	}
+
+	/**
+	* Filter arguments used to create the 'sizes' attribute value.
+	*
+	* @since 2.4.0
+	* @deprecated 3.0.0 Use 'wp_calculate_image_srcset'
+	* @see 'wp_calculate_image_srcset'
+	*
+	* @param array        $args An array of arguments used to create a 'sizes' attribute.
+	* @param int          $id   Post ID of the original image.
+	* @param array|string $size Image size. Image size or an array of width and height
+	*                           values in pixels (in that order).
+	*/
+	$args = apply_filters( 'tevkori_image_sizes_args', $args, $id, $size );
+
+	// If sizes is passed as a string, just use the string.
+	if ( is_string( $args['sizes'] ) ) {
+		$size_list = $args['sizes'];
+
+	// Otherwise, breakdown the array and build a sizes string.
+	} elseif ( is_array( $args['sizes'] ) ) {
+		$size_list = '';
+
+		foreach ( $args['sizes'] as $size ) {
+			// Use 100vw as the size value unless something else is specified.
+			$size_value = ( $size['size_value'] ) ? $size['size_value'] : '100vw';
+
+			// If a media length is specified, build the media query.
+			if ( ! empty( $size['mq_value'] ) ) {
+				$media_length = $size['mq_value'];
+
+				// Use max-width as the media condition unless min-width is specified.
+				$media_condition = ( ! empty( $size['mq_name'] ) ) ? $size['mq_name'] : 'max-width';
+
+				// If a media length was set, create the media query.
+				$media_query = '(' . $media_condition . ": " . $media_length . ') ';
+			} else {
+				// If no media length was set, '$media_query' is blank.
+				$media_query = '';
+			}
+			// Add to the source size list string.
+			$size_list .= $media_query . $size_value . ', ';
+		}
+		// Remove the trailing comma and space from the end of the string.
+		$size_list = substr( $size_list, 0, -2 );
+	}
+
+	// If '$size_list' is defined return the string, otherwise return '$sizes'.
+	return ( $size_list ) ? $size_list : $sizes;
 }
 add_filter( 'wp_calculate_image_sizes', '_tevkori_image_sizes_args_shim', 1, 5 );
+
+/**
+ * Private function to cache `$args` param from `tevkori_get_sizes()`.
+ *
+ * @since 3.1.0
+ * @access private
+ *
+ * @param array|bool $args Optional. The parsed value of the `$args` param from
+ *                         `tevkori_get_sizes()` or `false` to unset the saved value.
+ * @return array|bool The cached `$args` value or false is none is set.
+ */
+function _tevkori_sizes_has_args( $args = null ) {
+	static $return_args = false;
+
+	if ( false === $args ) {
+		$return_args = false;
+	} elseif ( is_array( $args ) ) {
+		$return_args = $args;
+	}
+
+	return $return_args;
+}
 
 /**
  * Returns a 'sizes' attribute.


### PR DESCRIPTION
@jaspermdegroot I've been playing with a way of doing this without the use of a global variable and came up with a few ways of streamlining the process, I think.

First, I added a helper function, `_tevkori_sizes_has_args()` that caches the parsed `$args` param from `tevkori_get_sizes()` (when applicable). The same helper function can also be used to unset the cached `$args` value by passing in `false`.

In your shim function, I test to see if there is a cached `$args` param or a filter hooked to `tevkori_image_sizes_args` and bail early if not (which you were already doing). 

When there is not a cached `$args` param but there is a filter, I recreate the default parsed `$args` from the original `tevkori_get_sizes()` instead of transforming the $sizes attribute into an array. Functionally, I believe you end up at the same place, but this was much easier for me to read.

I also added a unit test that makes sure that filters hooked into `tevkori_image_sizes_args` still fire when we call `wp_calculate_image_sizes()` directly.

One sidenote that I discovered in the process is that we have the second and third params of `wp_calculate_image_sizes()` documented as optional, but we never set default values for them. I'll open a separate tickets to address that here and in WP Core.