### PR TITLE
Display a notice when deprecated filter hooks are used

### DIFF
--- a/tests/test-suite.php
+++ b/tests/test-suite.php
@@ -72,6 +72,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 
 	/**
 	 * @expectedDeprecated tevkori_get_sizes
+	 * @expectedException PHPUnit_Framework_Error_Notice
 	 */
 	function test_tevkori_get_sizes_with_args() {
 		// Make an image.
@@ -103,6 +104,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 
 	/**
 	 * @expectedDeprecated tevkori_get_sizes
+	 * @expectedException PHPUnit_Framework_Error_Notice
 	 */
 	function test_filter_tevkori_get_sizes_string() {
 		// Add our test filter.
@@ -128,6 +130,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 
 	/**
 	 * @expectedDeprecated tevkori_get_srcset_array
+	 * @expectedException PHPUnit_Framework_Error_Notice
 	 */
 	function test_filter_tevkori_srcset_array() {
 		// Add test filter.
@@ -177,6 +180,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 
 	/**
 	 * @expectedDeprecated tevkori_get_srcset_array
+	 * @expectedException PHPUnit_Framework_Error_Notice
 	 */
 	function test_tevkori_get_srcset_array() {
 		// make an image
@@ -201,6 +205,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 
 	/**
 	 * @expectedDeprecated tevkori_get_srcset_array
+	 * @expectedException PHPUnit_Framework_Error_Notice
 	 */
 	function test_tevkori_get_srcset_array_random_size_name() {
 		// Make an image.
@@ -225,6 +230,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 
 	/**
 	 * @expectedDeprecated tevkori_get_srcset_array
+	 * @expectedException PHPUnit_Framework_Error_Notice
 	 */
 	function test_tevkori_get_srcset_array_no_date_upoads() {
 		// Save the current setting for uploads folders.
@@ -275,6 +281,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 	 * Test for filtering out leftover sizes after an image is edited.
 	 * @group 155
 	 * @expectedDeprecated tevkori_get_srcset_array
+	 * @expectedException PHPUnit_Framework_Error_Notice
 	 */
 	function test_tevkori_get_srcset_array_with_edits() {
 		// Make an image.

--- a/wp-tevko-deprecated-functions.php
+++ b/wp-tevko-deprecated-functions.php
@@ -1,5 +1,25 @@
 <?php
 /**
+ * Mark a filter hook as deprecated and inform when it has been used.
+ *
+ * @since 3.1.0
+ * @access private
+ *
+ * @param string $filter      The filter hook that was used.
+ * @param string $version     The version that deprecated the filter hook.
+ * @param string $replacement Optional. The filter hook that should have been used. Default null.
+ */
+function _tevkori_deprecated_filter( $filter, $version, $replacement = null ) {
+	if ( WP_DEBUG ) {
+		if ( ! is_null( $replacement ) ) {
+			trigger_error( sprintf( 'Filter hook %1$s is <strong>deprecated</strong> since version %2$s! Use %3$s instead.', $filter, $version, $replacement ) );
+		} else {
+			trigger_error( sprintf( 'Filter hook %1$s is <strong>deprecated</strong> since version %2$s with no alternative available.', $filter, $version ) );
+		}
+	}
+}
+
+/**
  * Returns an array of image sources for a 'srcset' attribute.
  *
  * @since 2.1.0
@@ -43,6 +63,7 @@ function tevkori_get_srcset_array( $id, $size = 'medium' ) {
 	 * @param array|string $size  Image size. Image size or an array of width and height
 	 *                            values in pixels (in that order).
 	 */
+	_tevkori_deprecated_filter( 'tevkori_srcset_array', '3.0.0', 'wp_calculate_image_srcset' );
 	return apply_filters( 'tevkori_srcset_array', $arr, $id, $size );
 }
 
@@ -164,6 +185,7 @@ function tevkori_get_sizes( $id, $size = 'medium', $args = null ) {
 		* @param array|string $size Image size. Image size or an array of width and height
 		*                           values in pixels (in that order).
 		*/
+		_tevkori_deprecated_filter( 'tevkori_image_sizes_args', '3.0.0', 'wp_calculate_image_sizes' );
 		$args = apply_filters( 'tevkori_image_sizes_args', $args, $id, $size );
 
 		// If sizes is passed as a string, just use the string.
@@ -300,6 +322,7 @@ function wp_get_attachment_image_sizes_filter_shim( $sizes, $size, $image_src, $
 		 * @param int          $attachment_id Image attachment ID of the original image.
 		 * @param string       $image_src     Optional. The URL to the image file.
 		 */
+		_tevkori_deprecated_filter( 'wp_get_attachment_image_sizes', '3.1.0', 'wp_calculate_image_sizes' );
 		return apply_filters( 'wp_get_attachment_image_sizes', $sizes, $size, $image_meta, $attachment_id, $image_src );
 	} else {
 		return $sizes;

--- a/wp-tevko-deprecated-functions.php
+++ b/wp-tevko-deprecated-functions.php
@@ -4,7 +4,7 @@
  *
  * @since 2.1.0
  * @deprecated 3.0.0 Use 'wp_get_attachment_image_srcset()'
- * @see 'wp_get_attachment_image_sizes()'
+ * @see 'wp_get_attachment_image_srcset()'
  * @see 'wp_calculate_image_srcset()'
  *
  * @param int          $id   Image attachment ID.
@@ -51,7 +51,7 @@ function tevkori_get_srcset_array( $id, $size = 'medium' ) {
  *
  * @since 2.3.0
  * @deprecated 3.0.0 Use 'wp_get_attachment_image_srcset()'
- * @see 'wp_get_attachment_image_sizes()'
+ * @see 'wp_get_attachment_image_srcset()'
  * @see 'wp_calculate_image_srcset()'
  *
  * @param int          $id   Image attachment ID.
@@ -76,7 +76,7 @@ function tevkori_get_srcset( $id, $size = 'medium' ) {
  *
  * @since 2.1.0
  * @deprecated 3.0.0 Use 'wp_get_attachment_image_srcset()'
- * @see 'wp_get_attachment_image_sizes()'
+ * @see 'wp_get_attachment_image_srcset()'
  * @see 'wp_calculate_image_srcset()'
  *
  * @param int          $id   Image attachment ID.
@@ -104,6 +104,7 @@ function tevkori_get_srcset_string( $id, $size = 'medium' ) {
  * @since 2.2.0
  * @deprecated 3.0.0 Use 'wp_get_attachment_image_sizes()'
  * @see 'wp_get_attachment_image_sizes()'
+ * @see 'wp_calculate_image_sizes()'
  *
  * @param int          $id   Image attachment ID.
  * @param array|string $size Image size. Accepts any valid image size, or an array of width and height
@@ -155,8 +156,8 @@ function tevkori_get_sizes( $id, $size = 'medium', $args = null ) {
 		* Filter arguments used to create the 'sizes' attribute value.
 		*
 		* @since 2.4.0
-		* @deprecated 3.0.0 Use 'wp_get_attachment_image_sizes'
-		* @see 'wp_get_attachment_image_sizes'
+		* @deprecated 3.0.0 Use 'wp_calculate_image_sizes'
+		* @see 'wp_calculate_image_sizes'
 		*
 		* @param array        $args An array of arguments used to create a 'sizes' attribute.
 		* @param int          $id   Post ID of the original image.
@@ -217,6 +218,7 @@ function tevkori_get_sizes( $id, $size = 'medium', $args = null ) {
  * @since 2.2.0
  * @deprecated 3.0.0 Use 'wp_get_attachment_image_sizes()'
  * @see 'wp_get_attachment_image_sizes()'
+ * @see 'wp_calculate_image_sizes()'
  *
  * @param int          $id   Image attachment ID.
  * @param array|string $size Image size. Accepts any valid image size, or an array of width and height

--- a/wp-tevko-deprecated-functions.php
+++ b/wp-tevko-deprecated-functions.php
@@ -282,23 +282,25 @@ function tevkori_filter_attachment_image_attributes( $attr, $attachment, $size )
 	return $attr;
 }
 
-if ( has_filter( 'wp_get_attachment_image_sizes' ) ) :
 function wp_get_attachment_image_sizes_filter_shim( $sizes, $size, $image_src, $image_meta, $attachment_id ) {
-	/**
-	 * Filter the output of 'wp_get_attachment_image_sizes()'.
-	 *
-	 * @since 3.0.0
-	 * @deprecated 3.1.0 Use 'wp_calculate_image_sizes'
-	 * @see 'wp_calculate_image_sizes'
-	 *
-	 * @param string       $sizes         A source size value for use in a 'sizes' attribute.
-	 * @param array|string $size          Image size. Image size name, or an array of width and height
-	 *                                    values in pixels (in that order).
-	 * @param array        $image_meta    The image meta data as returned by 'wp_get_attachment_metadata()'.
-	 * @param int          $attachment_id Image attachment ID of the original image.
-	 * @param string       $image_src     Optional. The URL to the image file.
-	 */
-	 return apply_filters( 'wp_get_attachment_image_sizes', $sizes, $size, $image_meta, $attachment_id, $image_src );
+	if ( has_filter( 'wp_get_attachment_image_sizes' ) ) {
+		/**
+		 * Filter the output of 'wp_get_attachment_image_sizes()'.
+		 *
+		 * @since 3.0.0
+		 * @deprecated 3.1.0 Use 'wp_calculate_image_sizes'
+		 * @see 'wp_calculate_image_sizes'
+		 *
+		 * @param string       $sizes         A source size value for use in a 'sizes' attribute.
+		 * @param array|string $size          Image size. Image size name, or an array of width and height
+		 *                                    values in pixels (in that order).
+		 * @param array        $image_meta    The image meta data as returned by 'wp_get_attachment_metadata()'.
+		 * @param int          $attachment_id Image attachment ID of the original image.
+		 * @param string       $image_src     Optional. The URL to the image file.
+		 */
+		return apply_filters( 'wp_get_attachment_image_sizes', $sizes, $size, $image_meta, $attachment_id, $image_src );
+	} else {
+		return $sizes;
+	}
 }
 add_filter( 'wp_calculate_image_sizes', 'wp_get_attachment_image_sizes_filter_shim', 10, 5 );
-endif;


### PR DESCRIPTION
When I was working on this I noticed I made a mistake in 2e13277c4896fdb17b2491044e057e185a364d85. The first commit fixes that.