### PR TITLE
Only show a warning when filters are actually used

### DIFF
--- a/tests/test-suite.php
+++ b/tests/test-suite.php
@@ -72,7 +72,6 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 
 	/**
 	 * @expectedDeprecated tevkori_get_sizes
-	 * @expectedException PHPUnit_Framework_Error_Notice
 	 * @group 226
 	 */
 	function test_tevkori_get_sizes_with_args() {
@@ -123,6 +122,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @expectedException PHPUnit_Framework_Error_Notice
 	 * @group 226
 	 */
 	function test_filter_shim_calculate_image_sizes() {
@@ -199,7 +199,6 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 
 	/**
 	 * @expectedDeprecated tevkori_get_srcset_array
-	 * @expectedException PHPUnit_Framework_Error_Notice
 	 */
 	function test_tevkori_get_srcset_array() {
 		// make an image
@@ -224,7 +223,6 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 
 	/**
 	 * @expectedDeprecated tevkori_get_srcset_array
-	 * @expectedException PHPUnit_Framework_Error_Notice
 	 */
 	function test_tevkori_get_srcset_array_random_size_name() {
 		// Make an image.
@@ -249,7 +247,6 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 
 	/**
 	 * @expectedDeprecated tevkori_get_srcset_array
-	 * @expectedException PHPUnit_Framework_Error_Notice
 	 */
 	function test_tevkori_get_srcset_array_no_date_upoads() {
 		// Save the current setting for uploads folders.
@@ -300,7 +297,6 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 	 * Test for filtering out leftover sizes after an image is edited.
 	 * @group 155
 	 * @expectedDeprecated tevkori_get_srcset_array
-	 * @expectedException PHPUnit_Framework_Error_Notice
 	 */
 	function test_tevkori_get_srcset_array_with_edits() {
 		// Make an image.

--- a/wp-tevko-deprecated-functions.php
+++ b/wp-tevko-deprecated-functions.php
@@ -63,7 +63,9 @@ function tevkori_get_srcset_array( $id, $size = 'medium' ) {
 	 * @param array|string $size  Image size. Image size or an array of width and height
 	 *                            values in pixels (in that order).
 	 */
-	_tevkori_deprecated_filter( 'tevkori_srcset_array', '3.0.0', 'wp_calculate_image_srcset' );
+	if ( has_filter( 'tevkori_srcset_array' ) ) {
+		_tevkori_deprecated_filter( 'tevkori_srcset_array', '3.0.0', 'wp_calculate_image_srcset' );
+	}
 	return apply_filters( 'tevkori_srcset_array', $arr, $id, $size );
 }
 
@@ -269,6 +271,9 @@ function _tevkori_image_sizes_args_shim( $sizes, $size, $image_src, $image_meta,
 	* @param array|string $size Image size. Image size or an array of width and height
 	*                           values in pixels (in that order).
 	*/
+	if ( has_filter( 'tevkori_image_sizes_args' ) ) {
+		_tevkori_deprecated_filter( 'tevkori_image_sizes_args', '3.0.0', 'wp_calculate_image_sizes' );
+	}
 	$args = apply_filters( 'tevkori_image_sizes_args', $args, $id, $size );
 
 	// If sizes is passed as a string, just use the string.


### PR DESCRIPTION
Fixes https://github.com/ResponsiveImagesCG/wp-tevko-responsive-images/issues/245