### PR TITLE
Cleanup tests

### DIFF
--- a/tests/test-suite.php
+++ b/tests/test-suite.php
@@ -16,8 +16,8 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 	}
 
 	public static function create_upload_object( $filename, $parent = 0 ) {
-		$contents = file_get_contents($filename);
-		$upload = wp_upload_bits(basename($filename), null, $contents);
+		$contents = file_get_contents( $filename );
+		$upload = wp_upload_bits(basename( $filename ), null, $contents );
 		$type = '';
 
 		if ( ! empty($upload['type'] ) ) {
@@ -157,7 +157,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 
 		// Set up our test.
 		$id = self::$large_id;
-		$srcset = tevkori_get_srcset_array($id, 'medium');
+		$srcset = tevkori_get_srcset_array( $id, 'medium' );
 
 		// Evaluate that the sizes returned is what we expected.
 		foreach( $srcset as $width => $source ) {
@@ -307,7 +307,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 		$meta = wp_get_attachment_metadata( $id );
 
 		// Mimick hash generation method used in wp_save_image().
-		$hash = 'e' . time() . rand(100, 999);
+		$hash = 'e' . time() . rand( 100, 999 );
 
 		// Replace file paths for full and medium sizes with hashed versions.
 		$filename_base = basename( $meta['file'], '.png' );
@@ -362,7 +362,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 	 * Helper funtion to filter image_downsize and return zero values for width and height.
 	 */
 	public function _filter_image_downsize( $out, $id, $size ) {
-		$img_url = wp_get_attachment_url($id);
+		$img_url = wp_get_attachment_url( $id );
 		return array( $img_url, 0, 0 );
 	}
 
@@ -555,7 +555,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 		$large_src = 'http://example.org/wp-content/uploads/' . $image_meta['sizes']['large']['file'];
 
 		// Test with soft resized size array.
-		$size_array = array(900, 450);
+		$size_array = array( 900, 450 );
 
 		// Full size GIFs should not return a srcset.
 		$this->assertFalse( wp_calculate_image_srcset( $full_src, $size_array, $image_meta ) );

--- a/tests/test-suite.php
+++ b/tests/test-suite.php
@@ -157,10 +157,10 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 
 		// Set up our test.
 		$id = self::$large_id;
-		$sizes = tevkori_get_srcset_array($id, 'medium');
+		$srcset = tevkori_get_srcset_array($id, 'medium');
 
 		// Evaluate that the sizes returned is what we expected.
-		foreach( $sizes as $width => $source ) {
+		foreach( $srcset as $width => $source ) {
 			$this->assertTrue( $width <= 500 );
 		}
 
@@ -203,7 +203,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 	function test_tevkori_get_srcset_array() {
 		// make an image
 		$id = self::$large_id;
-		$sizes = tevkori_get_srcset_array( $id, 'medium' );
+		$srcset = tevkori_get_srcset_array( $id, 'medium' );
 
 		$year_month = date('Y/m');
 		$image = wp_get_attachment_metadata( $id );
@@ -218,7 +218,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 		// Add the full size width at the end.
 		$expected[$image['width']] = 'http://example.org/wp-content/uploads/' . $image['file'] . ' ' . $image['width'] .'w';
 
-		$this->assertSame( $expected, $sizes );
+		$this->assertSame( $expected, $srcset );
 	}
 
 	/**
@@ -227,7 +227,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 	function test_tevkori_get_srcset_array_random_size_name() {
 		// Make an image.
 		$id = self::$large_id;
-		$sizes = tevkori_get_srcset_array( $id, 'foo' );
+		$srcset = tevkori_get_srcset_array( $id, 'foo' );
 
 		$year_month = date('Y/m');
 		$image = wp_get_attachment_metadata( $id );
@@ -242,7 +242,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 		// Add the full size width at the end.
 		$expected[$image['width']] = 'http://example.org/wp-content/uploads/' . $image['file'] . ' ' . $image['width'] .'w';
 
-		$this->assertSame( $expected, $sizes );
+		$this->assertSame( $expected, $srcset );
 	}
 
 	/**
@@ -257,7 +257,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 
 		// Make an image.
 		$id = self::create_upload_object( self::$test_file_name );
-		$sizes = tevkori_get_srcset_array( $id, 'medium' );
+		$srcset = tevkori_get_srcset_array( $id, 'medium' );
 		$image = wp_get_attachment_metadata( $id );
 
 		foreach( $image['sizes'] as $name => $size ) {
@@ -270,7 +270,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 		// Add the full size width at the end.
 		$expected[$image['width']] = 'http://example.org/wp-content/uploads/' . $image['file'] . ' ' . $image['width'] .'w';
 
-		$this->assertSame( $expected, $sizes );
+		$this->assertSame( $expected, $srcset );
 
 		// Leave the uploads option the way you found it.
 		update_option( 'uploads_use_yearmonth_folders', $uploads_use_yearmonth_folders );
@@ -287,7 +287,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 		 * In our tests, thumbnails would only return a single srcset candidate,
 		 * in which case we don't bother returning a srcset array.
 		 */
-		$sizes = tevkori_get_srcset( $id, 'thumbnail' );
+		$srcset = tevkori_get_srcset( $id, 'thumbnail' );
 
 		$this->assertTrue( 1 === count( tevkori_get_srcset_array( $id, 'thumbnail' ) ) );
 		$this->assertFalse( tevkori_get_srcset( $id, 'thumbnail' ) );
@@ -323,11 +323,11 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 		$img_url = wp_get_attachment_url( $id );
 
 		// Calculate a srcset array.
-		$sizes = tevkori_get_srcset_array( $id, 'medium' );
+		$srcset = tevkori_get_srcset_array( $id, 'medium' );
 
 		// Test to confirm all sources in the array include the same edit hash.
-		foreach ( $sizes as $size ) {
-			$this->assertTrue( false !== strpos( $size, $hash ) );
+		foreach ( $srcset as $source ) {
+			$this->assertTrue( false !== strpos( $source, $hash ) );
 		}
 	}
 
@@ -337,10 +337,10 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 	function test_tevkori_get_srcset_array_false() {
 		// Make an image.
 		$id = self::$large_id;
-		$sizes = tevkori_get_srcset_array( 99999, 'foo' );
+		$srcset = tevkori_get_srcset_array( 99999, 'foo' );
 
 		// For canola.jpg we should return.
-		$this->assertFalse( $sizes );
+		$this->assertFalse( $srcset );
 	}
 
 	/**
@@ -374,26 +374,26 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 	function test_tevkori_get_srcset_string() {
 		// Make an image.
 		$id = self::$large_id;
-		$sizes = tevkori_get_srcset_string( $id, 'full-size' );
+		$srcset = tevkori_get_srcset_string( $id, 'full-size' );
 
-		$sizes = tevkori_get_srcset_string( $id, 'full' );
+		$srcset = tevkori_get_srcset_string( $id, 'full' );
 		$image = wp_get_attachment_metadata( $id );
 		$year_month = date('Y/m');
 
-		$srcset = '';
+		$expected = '';
 
 		foreach( $image['sizes'] as $name => $size ) {
 			// Whitelist the sizes that should be included so we pick up 'medium_large' in 4.4.
 			if ( in_array( $name, array( 'medium', 'medium_large', 'large' ) ) ) {
-				$srcset .= 'http://example.org/wp-content/uploads/' . $year_month = date('Y/m') . '/' . $size['file'] . ' ' . $size['width'] . 'w, ';
+				$expected .= 'http://example.org/wp-content/uploads/' . $year_month = date('Y/m') . '/' . $size['file'] . ' ' . $size['width'] . 'w, ';
 			}
 		}
 		// Add the full size width at the end.
-		$srcset .= 'http://example.org/wp-content/uploads/' . $image['file'] . ' ' . $image['width'] .'w';
+		$expected .= 'http://example.org/wp-content/uploads/' . $image['file'] . ' ' . $image['width'] .'w';
 
-		$expected = sprintf( 'srcset="%s"', $srcset );
+		$expected = sprintf( 'srcset="%s"', $expected );
 
-		$this->assertSame( $expected, $sizes );
+		$this->assertSame( $expected, $srcset );
 	}
 
 	/**

--- a/tests/test-suite.php
+++ b/tests/test-suite.php
@@ -287,8 +287,6 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 		 * In our tests, thumbnails would only return a single srcset candidate,
 		 * in which case we don't bother returning a srcset array.
 		 */
-		$srcset = tevkori_get_srcset( $id, 'thumbnail' );
-
 		$this->assertTrue( 1 === count( tevkori_get_srcset_array( $id, 'thumbnail' ) ) );
 		$this->assertFalse( tevkori_get_srcset( $id, 'thumbnail' ) );
 	}
@@ -374,7 +372,6 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 	function test_tevkori_get_srcset_string() {
 		// Make an image.
 		$id = self::$large_id;
-		$srcset = tevkori_get_srcset_string( $id, 'full-size' );
 
 		$srcset = tevkori_get_srcset_string( $id, 'full' );
 		$image = wp_get_attachment_metadata( $id );

--- a/tests/test-suite.php
+++ b/tests/test-suite.php
@@ -524,43 +524,43 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 	}
 
 	function test_wp_calculate_image_srcset_animated_gifs() {
-	// Mock meta for an animated gif.
-	$image_meta = array(
-		'width' => 1200,
-		'height' => 600,
-		'file' => 'animated.gif',
-		'sizes' => array(
-			'thumbnail' => array(
-				'file' => 'animated-150x150.gif',
-				'width' => 150,
-				'height' => 150,
-				'mime-type' => 'image/gif'
-			),
-			'medium' => array(
-				'file' => 'animated-300x150.gif',
-				'width' => 300,
-				'height' => 150,
-				'mime-type' => 'image/gif'
-			),
-			'large' => array(
-				'file' => 'animated-1024x512.gif',
-				'width' => 1024,
-				'height' => 512,
-				'mime-type' => 'image/gif'
-			),
-		)
-	);
+		// Mock meta for an animated gif.
+		$image_meta = array(
+			'width' => 1200,
+			'height' => 600,
+			'file' => 'animated.gif',
+			'sizes' => array(
+				'thumbnail' => array(
+					'file' => 'animated-150x150.gif',
+					'width' => 150,
+					'height' => 150,
+					'mime-type' => 'image/gif'
+				),
+				'medium' => array(
+					'file' => 'animated-300x150.gif',
+					'width' => 300,
+					'height' => 150,
+					'mime-type' => 'image/gif'
+				),
+				'large' => array(
+					'file' => 'animated-1024x512.gif',
+					'width' => 1024,
+					'height' => 512,
+					'mime-type' => 'image/gif'
+				),
+			)
+		);
 
-	$full_src  = 'http://example.org/wp-content/uploads/' . $image_meta['file'];
-	$large_src = 'http://example.org/wp-content/uploads/' . $image_meta['sizes']['large']['file'];
+		$full_src  = 'http://example.org/wp-content/uploads/' . $image_meta['file'];
+		$large_src = 'http://example.org/wp-content/uploads/' . $image_meta['sizes']['large']['file'];
 
-	// Test with soft resized size array.
-	$size_array = array(900, 450);
+		// Test with soft resized size array.
+		$size_array = array(900, 450);
 
-	// Full size GIFs should not return a srcset.
-	$this->assertFalse( wp_calculate_image_srcset( $full_src, $size_array, $image_meta ) );
-	// Intermediate sized GIFs should not include the full size in the srcset.
-	$this->assertFalse( strpos( wp_calculate_image_srcset( $large_src, $size_array, $image_meta ), $full_src ) );
-}
+		// Full size GIFs should not return a srcset.
+		$this->assertFalse( wp_calculate_image_srcset( $full_src, $size_array, $image_meta ) );
+		// Intermediate sized GIFs should not include the full size in the srcset.
+		$this->assertFalse( strpos( wp_calculate_image_srcset( $large_src, $size_array, $image_meta ), $full_src ) );
+	}
 
 }

--- a/tests/test-suite.php
+++ b/tests/test-suite.php
@@ -225,7 +225,7 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Helper funtion to filter image_downsize and return zero values for width and height.
+	 * Helper function to filter image_downsize and return zero values for width and height.
 	 */
 	public function _filter_image_downsize( $out, $id, $size ) {
 		$img_url = wp_get_attachment_url( $id );
@@ -301,8 +301,8 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @expectedDeprecated tevkori_get_sizes
 	 * @group 226
+	 * @expectedDeprecated tevkori_get_sizes
 	 */
 	function test_tevkori_get_sizes_with_args() {
 		// Make an image.
@@ -341,9 +341,9 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @group 226
 	 * @expectedDeprecated tevkori_get_sizes
 	 * @expectedException PHPUnit_Framework_Error_Notice
-	 * @group 226
 	 */
 	function test_filter_tevkori_get_sizes() {
 		// Add our test filter.
@@ -360,8 +360,8 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @expectedException PHPUnit_Framework_Error_Notice
 	 * @group 226
+	 * @expectedException PHPUnit_Framework_Error_Notice
 	 */
 	function test_filter_shim_calculate_image_sizes() {
 		// Add our test filter.
@@ -523,6 +523,9 @@ class RICG_Responsive_Images_Tests extends WP_UnitTestCase {
 		$this->assertFalse( isset( $resp_attr['sizes'] ) );
 	}
 
+	/**
+	 * Test if full size GIFs don't get a srcset.
+	 */
 	function test_wp_calculate_image_srcset_animated_gifs() {
 		// Mock meta for an animated gif.
 		$image_meta = array(


### PR DESCRIPTION
I cherry-picked the commit from the 'fix-deprecation-warnings' branch (PR #246) to avoid merge conflicts. So we should merge that PR first and then rebase this 'cleanup-tests' branch to drop the commit before merging this PR.

I don't really understand how the `@group` numbering works. Some tests belong to a group, some don't. @joemcgill maybe you can give that look or explain it to me.